### PR TITLE
DiscreteAccessoryTypeEnum ordering correction

### DIFF
--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedComponentElements/Types/IfcDiscreteAccessoryTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedComponentElements/Types/IfcDiscreteAccessoryTypeEnum/DocEnumeration.xml
@@ -23,9 +23,10 @@
 		<DocConstant xsi:nil="true" href="POINTMACHINEMOUNTINGDEVICE_2on26g2aPBBBfbJkmZ7Rgk" />
 		<DocConstant xsi:nil="true" href="POINT_MACHINE_LOCKING_DEVICE_34yTv_ren5suPlmb5x41Mz" />
 		<DocConstant xsi:nil="true" href="RAIL_MECHANICAL_EQUIPMENT_1AAjvBrmbFowAioX999d0U" />
+		<DocConstant xsi:nil="true" href="BIRDPROTECTION_2zJk1z7ErBp9BvzQN9mC1z" />
 		<DocConstant xsi:nil="true" href="USERDEFINED_2Y_gtzHLrB8RkBdNo3J4AA" />
 		<DocConstant xsi:nil="true" href="NOTDEFINED_2HYMa5znnEhRVchh9wxGaP" />
-		<DocConstant xsi:nil="true" href="BIRDPROTECTION_2zJk1z7ErBp9BvzQN9mC1z" />
+		
 	</Constants>
 </DocEnumeration>
 


### PR DESCRIPTION
### Developments Undertaken

Reordered Enum so convention of USERDEFINED & NOTDEFINED is at the end

### NOTES
None see Issue