### PR TITLE
correction of Feature Element documentation Fixes #29

### DIFF
--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
@@ -4,7 +4,7 @@ The _IfcFeatureElementAddition_ is associated to its master element by virtue of
 
 The local placement for _IfcFeatureElementAddition_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the element to which the feature element is added:
 
-* The _PlacementRelTo_ attribute of _IfcObjectPlacement_ shall point to the object placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute (the parent element of the feature).
+* The _PlacementRelTo_ attribute of _IfcObjectPlacement_ shall point (if given) to the object placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
@@ -4,7 +4,7 @@ The _IfcFeatureElementAddition_ is associated to its master element by virtue of
 
 The local placement for _IfcFeatureElementAddition_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the element to which the feature element is added:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point to the local placement of the same _IfcElement_, which is used in the _HasAdditionFeature.RelatingElement_ inverse attribute. 
+* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point to the local placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute. ( the parent element of the feature ).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
@@ -4,7 +4,7 @@ The _IfcFeatureElementAddition_ is associated to its master element by virtue of
 
 The local placement for _IfcFeatureElementAddition_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the element to which the feature element is added:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point to the local placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute. ( the parent element of the feature ).
+* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point to the local placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute. (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementAddition/Documentation.md
@@ -4,7 +4,7 @@ The _IfcFeatureElementAddition_ is associated to its master element by virtue of
 
 The local placement for _IfcFeatureElementAddition_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the element to which the feature element is added:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point to the local placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute. (the parent element of the feature).
+* The _PlacementRelTo_ attribute of _IfcObjectPlacement_ shall point to the object placement of the _IfcElement_, which is used in the _ProjectsElements.RelatingElement_ inverse attribute (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
@@ -6,7 +6,7 @@ The voiding relationship between a master element and a subtraction feature is g
 
 The local placement for _IfcFeatureElementSubtraction_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the building element from which the feature element substration is substracted:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the same _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute.
+* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute. ( the parent element of the feature ).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
@@ -6,7 +6,7 @@ The voiding relationship between a master element and a subtraction feature is g
 
 The local placement for _IfcFeatureElementSubtraction_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the building element from which the feature element substration is substracted:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute. (the parent element of the feature).
+* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
@@ -6,7 +6,7 @@ The voiding relationship between a master element and a subtraction feature is g
 
 The local placement for _IfcFeatureElementSubtraction_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the building element from which the feature element substration is substracted:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute (the parent element of the feature).
+* The _PlacementRelTo_ attribute of _IfcObjectPlacement_ shall point (if given) to the object placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcFeatureElementSubtraction/Documentation.md
@@ -6,7 +6,7 @@ The voiding relationship between a master element and a subtraction feature is g
 
 The local placement for _IfcFeatureElementSubtraction_ is defined in its supertype _IfcProduct_. It is defined by the _IfcLocalPlacement_, which defines the local coordinate system that is referenced by all geometric representations. The local placement is always defined in relation to the local placement of the building element from which the feature element substration is substracted:
 
-* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute. ( the parent element of the feature ).
+* The _PlacementRelTo_ relationship of _IfcLocalPlacement_ shall point (if given) to the local placement of the _IfcElement_, which is used in the _VoidsElements.RelatingElement_ inverse attribute. (the parent element of the feature).
 
 > HISTORY&nbsp; New entity in IFC2x2.
 


### PR DESCRIPTION
correction to IfcFeatureElementAddition documentation to add correct attribute path on explanation, it mirrors the same statement on IfcFeatureElementSubtraction.