### PR TITLE
Feature: README badges for Issue management

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -4,7 +4,8 @@ name: Issue-Managemment
 on: workflow_dispatch
 
 jobs:
-  runs-on: ubuntu-latest
+  generate-kpis:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ABCon-Tech/KPI-action@v1

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,5 +1,5 @@
 
-name: Issue-Managemment
+name: Issue-Management
 
 on: workflow_dispatch
 

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,19 @@
+
+name: Issue-Managemment
+
+on: workflow_dispatch
+
+jobs:
+  runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ABCon-Tech/KPI-action@v1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: summary
+          path: ${{ github.workspace }}/Management/Summary.md
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v7.2.1
+        with:
+          branch: management
+          default_author: user_info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # IFC Specification
+![Release-Badge](https://img.shields.io/github/v/release/bSI-InfraRoom/IFC-Specification)
+![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/bSI-InfraRoom/IFC-Specification/4.3.RC4)
+![GitHub contributors](https://img.shields.io/github/contributors/bSI-InfraRoom/IFC-Specification)
+![GitHub forks](https://img.shields.io/github/forks/bSI-InfraRoom/IFC-Specification)
 
 This repository contains the IFC specification content:
 
@@ -9,9 +13,21 @@ This repository contains the IFC specification content:
 
 Fork, commit, pull request.
 
+## Issue Management
+
+![GitHub issues](https://img.shields.io/github/issues/bSI-InfraRoom/IFC-Specification)
+![GitHub issues by-label](https://img.shields.io/github/issues/bSI-InfraRoom/IFC-Specification/IFC4x3_RC4)
+![GitHub closed issues](https://img.shields.io/github/issues-closed/bSI-InfraRoom/IFC-Specification)
+
+
+![GitHub pull requests](https://img.shields.io/github/issues-pr/bSI-InfraRoom/IFC-Specification)
+![GitHub pull requests by-label](https://img.shields.io/github/issues-pr/bSI-InfraRoom/IFC-Specification/IFC4x3_RC4)
+![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/bSI-InfraRoom/IFC-Specification)
+
 ## Tooling
 
 [Github Desktop](https://desktop.github.com/) for working on pull requests:
 
 - Click on Current branch and switch to Pull requests
 - Fetch origin (if not yet initiated automatically)
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IFC Specification
 ![Release-Badge](https://img.shields.io/github/v/release/bSI-InfraRoom/IFC-Specification)
-![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/bSI-InfraRoom/IFC-Specification/4.3.RC4)
+![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/bSI-InfraRoom/IFC-Specification/IFC4x3_RC4)
 ![GitHub contributors](https://img.shields.io/github/contributors/bSI-InfraRoom/IFC-Specification)
 ![GitHub forks](https://img.shields.io/github/forks/bSI-InfraRoom/IFC-Specification)
 


### PR DESCRIPTION
## Update
- [x] Added some information badges to heading in preperation for GitFlow use and controlled release management
- [x] Added badges that recover the count of pull requests and issues from the repository.

## To Do

- [x] Add GitHub actions to generate some simple reports/ markdown pages with the information requested by Christophe