### PR TITLE
Updates in alignment model

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentCantSegment/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentCantSegment/DocEntity.xml
@@ -4,7 +4,7 @@
 		<DocAttribute Name="StartDistAlong" UniqueId="6a411ff4-fa52-4c6a-a3de-5896627dc575" DefinedType="IfcLengthMeasure">
 			<Documentation>Distance along the horizontal alignment, measured along the IfcAlignment2DHorizontal given in the length unit of the global IfcUnitAssignment.</Documentation>
 		</DocAttribute>
-		<DocAttribute Name="HorizontalLength" UniqueId="ebd5ee92-1836-4c92-bfb5-4ef80d9eeceb" DefinedType="IfcPositiveLengthMeasure">
+		<DocAttribute Name="HorizontalLength" UniqueId="ebd5ee92-1836-4c92-bfb5-4ef80d9eeceb" DefinedType="IfcNonNegativeLengthMeasure">
 			<Documentation>Length measured as distance along the horizontal alignment of the segment.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="StartCantLeft" UniqueId="035b7084-b76d-4b18-a9e8-2ddd020f1fc4" DefinedType="IfcLengthMeasure">

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentVerticalSegment/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentVerticalSegment/DocEntity.xml
@@ -9,7 +9,7 @@
 &gt; NOTE 1&amp;nbsp; The distance along is measured from the start point of _IfcAlignmentHorizontal_, any optionally provided offset expressed by _IfcAlignmentHorizontal_.StartDistanceAlong is not taken into account.
 &gt; NOTE 2&amp;nbsp; The unit of measurement is the global length unit, as set by _IfcContext_.UnitInContext</Documentation>
 		</DocAttribute>
-		<DocAttribute Name="HorizontalLength" UniqueId="a2fe23af-c8fa-4aab-9e63-c03f98770570" DefinedType="IfcPositiveLengthMeasure">
+		<DocAttribute Name="HorizontalLength" UniqueId="a2fe23af-c8fa-4aab-9e63-c03f98770570" DefinedType="IfcNonNegativeLengthMeasure">
 			<Documentation>Length measured as distance along the horizontal alignment of the segment.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="StartHeight" UniqueId="794b3cc4-cf59-4f6d-b090-699a8fb08638" DefinedType="IfcLengthMeasure">
@@ -22,8 +22,8 @@
 		<DocAttribute Name="EndGradient" UniqueId="f91fe698-cbc3-48f4-80f1-5b8a5b0c6f49" DefinedType="IfcRatioMeasure">
 			<Documentation>End gradient of the segment. In the case of a PredefinedType=&apos;.CONSTANTGRADIENT.&apos; the value is the same as _StartGradient_.</Documentation>
 		</DocAttribute>
-		<DocAttribute Name="RadiusOfCurvature" UniqueId="4c28f1e4-ef03-421a-a559-862cc0c31b7f" DefinedType="IfcPositiveLengthMeasure" AttributeFlags="1">
-			<Documentation>Radius of parabola or arc.
+		<DocAttribute Name="RadiusOfCurvature" UniqueId="4c28f1e4-ef03-421a-a559-862cc0c31b7f" DefinedType="IfcLengthMeasure" AttributeFlags="1">
+			<Documentation>Radius of parabola or arc. Positive values imply a CCW direction whereas negative CW, looked from the right side of alignment.
 &gt; NOTE1&amp;nbsp; For _PredefinedType_ is ARC. The radius of the basis circle for the arc.  
 &gt; NOTE2&amp;nbsp; For _PredefinedType_ is PARABOLICARC. Parabola constant (determining the “steepness” of the parabola). The parabola constant is provided by the “minimum parabola radius”, the true radius of a parabola at its vertical axis (the zero-gradient point of the parabola). The minimum radius is twice the focal length of the parabola (the distance between the focal point and the vertex).  
 &gt; NOTE3&amp;nbsp; For _PredefinedType_ that is not either ARC or PARABOLICARC the value should be empty.</Documentation>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentVerticalSegment/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricConstraintResource/Entities/IfcAlignmentVerticalSegment/DocEntity.xml
@@ -23,7 +23,7 @@
 			<Documentation>End gradient of the segment. In the case of a PredefinedType=&apos;.CONSTANTGRADIENT.&apos; the value is the same as _StartGradient_.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="RadiusOfCurvature" UniqueId="4c28f1e4-ef03-421a-a559-862cc0c31b7f" DefinedType="IfcLengthMeasure" AttributeFlags="1">
-			<Documentation>Radius of parabola or arc. Positive values imply a CCW direction whereas negative CW, looked from the right side of alignment.
+			<Documentation>Radius of parabola or arc. Positive values imply a CCW direction whereas negative CW.
 &gt; NOTE1&amp;nbsp; For _PredefinedType_ is ARC. The radius of the basis circle for the arc.  
 &gt; NOTE2&amp;nbsp; For _PredefinedType_ is PARABOLICARC. Parabola constant (determining the “steepness” of the parabola). The parabola constant is provided by the “minimum parabola radius”, the true radius of a parabola at its vertical axis (the zero-gradient point of the parabola). The minimum radius is twice the focal length of the parabola (the distance between the focal point and the vertex).  
 &gt; NOTE3&amp;nbsp; For _PredefinedType_ that is not either ARC or PARABOLICARC the value should be empty.</Documentation>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcSine/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcSine/DocEntity.xml
@@ -2,7 +2,8 @@
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcSine" UniqueId="5c328157-841c-42e0-b115-645a5bffa78d" BaseDefinition="IfcSpiral" EntityFlags="32">
 	<Attributes>
 		<DocAttribute Name="SineTerm" UniqueId="8c600f81-1953-4b6c-b47f-e5b40241b6ee" DefinedType="IfcLengthMeasure" />
-		<DocAttribute Name="LinearTerm" UniqueId="75d1f505-c3ab-46a6-a183-74a8db4fd1be" DefinedType="IfcLengthMeasure" />
+		<DocAttribute Name="LinearTerm" UniqueId="75d1f505-c3ab-46a6-a183-74a8db4fd1be" DefinedType="IfcLengthMeasure" AttributeFlags="1"/>
+		<DocAttribute Name="ConstantTerm" UniqueId="f76232c0-cf64-11eb-b8bc-0242ac130003" DefinedType="IfcReal" AttributeFlags="1"/>
 	</Attributes>
 </DocEntity>
 

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcThirdOrderPolynomialSpiral/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcThirdOrderPolynomialSpiral/DocEntity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcThirdOrderPolynomialSpiral" UniqueId="fb8706d9-cdf9-45c9-b533-ccd35b17d59c" BaseDefinition="IfcSpiral" EntityFlags="32">
 	<Attributes>
-		<DocAttribute Name="QubicTerm" UniqueId="a6a9e3ee-3806-4ee3-8f8a-2f7ca5474131" DefinedType="IfcLengthMeasure" />
+		<DocAttribute Name="CubicTerm" UniqueId="a6a9e3ee-3806-4ee3-8f8a-2f7ca5474131" DefinedType="IfcLengthMeasure" />
 		<DocAttribute Name="QuadraticTerm" UniqueId="3ca73660-f211-460e-82c4-deb0962f1ad7" DefinedType="IfcLengthMeasure" AttributeFlags="1" />
 		<DocAttribute Name="LinearTerm" UniqueId="4c87d0bb-ca6c-419c-be0a-d6abc25f8176" DefinedType="IfcLengthMeasure" AttributeFlags="1" />
 		<DocAttribute Name="ConstantTerm" UniqueId="72ef1e7a-7045-4313-9e88-6a769a7f53f4" DefinedType="IfcReal" AttributeFlags="1" />


### PR DESCRIPTION
# Update

- IfcSine: 
  - added ConstantTerm, link to #56 
- IfcThirdOrderPolynomialSpiral: 
  - QubicTerm to CubicTerm
- IfcAlignmentVerticalSegment: 
  - HorizontalLength, type changed to IfcNonNegativeLengthMeasure, link to #53 
  - RadiusOfCurvature, type changed to IfcLengthMeasure, link to #54 
- IfcAlignmentCantSegment: 
  - HorizontalLength, type changed to IfcNonNegativeLengthMeasure, link to #53