### PR TITLE
Two more PDTs of IfcCommunicationsAppliance 

### DIFF
--- a/IFC4x3/Constants/l/LINESIDEELECTRONICUNIT_3rnHFk$T1FxuW70w_6BT_r.xml
+++ b/IFC4x3/Constants/l/LINESIDEELECTRONICUNIT_3rnHFk$T1FxuW70w_6BT_r.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="LINESIDEELECTRONICUNIT_3rnHFkT1FxuW70w_6BT_r" Name="LINESIDEELECTRONICUNIT" UniqueId="f5c513ee-fdd0-4fef-8807-03af862ddfb5">
+	<Documentation>The lineside electronic unit (LEU) is the interface between the balise and interlocking in railway. The LEU acquires the information from the interlocking, and sends the appropriate information to the balises in concordance with the lineside signalling (if available).</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Constants/r/RADIOBLOCKCENTER_1tk6TqabH1PxL221xuLrnU.xml
+++ b/IFC4x3/Constants/r/RADIOBLOCKCENTER_1tk6TqabH1PxL221xuLrnU.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RADIOBLOCKCENTER_1tk6TqabH1PxL221xuLrnU" Name="RADIOBLOCKCENTER" UniqueId="77b86774-9254-4167-b542-081ef8575c5e">
+	<Documentation>A radio block center is a specialised computing device in railway with specification for generating Movement Authorities (MA) and transmitting it to trains. It gets information from signalling control and from the trains in its section.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcElectricalDomain/Types/IfcCommunicationsApplianceTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcElectricalDomain/Types/IfcCommunicationsApplianceTypeEnum/DocEnumeration.xml
@@ -27,6 +27,8 @@
 		<DocConstant xsi:nil="true" href="TRANSPONDER_3vbzqAsKzFZvMBS_Wuczs8" />
 		<DocConstant xsi:nil="true" href="TRANSPORTEQUIPMENT_2Dmbs7npn2hA9G24XlxTvi" />
 		<DocConstant xsi:nil="true" href="OPTICALLINETERMINAL_0FNoMmV852re3_Z31dD8u6" />
+		<DocConstant xsi:nil="true" href="LINESIDEELECTRONICUNIT_3rnHFkT1FxuW70w_6BT_r" />
+		<DocConstant xsi:nil="true" href="RADIOBLOCKCENTER_1tk6TqabH1PxL221xuLrnU" />
 		<DocConstant xsi:nil="true" href="USERDEFINED_3lrZTnZfX7g9adhf4PEnYC" />
 		<DocConstant xsi:nil="true" href="NOTDEFINED_0hF15nkf79uy7wMtnpxz" />
 	</Constants>


### PR DESCRIPTION
Two more PDTs for IfcCommunicationsAppliance: LINESIDEELECTRONICUNIT, RADIOBLOCKCENTER.
This change request is coming from the ERTMS storyline, and agreed in the Signalling domain group of IFC Rail.