### PR TITLE
Update Pset_ProcessCapacity ProcessItem Documentation

### DIFF
--- a/IFC4x3/Properties/p/ProcessItem_0yXM2dwTn71gpxHeftzb$S/Documentation.md
+++ b/IFC4x3/Properties/p/ProcessItem_0yXM2dwTn71gpxHeftzb$S/Documentation.md
@@ -1,1 +1,1 @@
-The type of cargo (and its measurement method) being modelled within a process.
+The type of item (and its measurement method) being modelled within a process. This can be cargo, passengers or vehicles that pass through the system.

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/PropertySets/Pset_ProcessCapacity/DocPropertySet.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/PropertySets/Pset_ProcessCapacity/DocPropertySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_ProcessCapacity" UniqueId="95ac3d01-c324-4bba-912c-4185b0bfce5d" ApplicableType="IfcSpatialElement,IfcSpatialElementType,IfcTransportElement,IfcTransportElementType" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_ProcessCapacity" UniqueId="95ac3d01-c324-4bba-912c-4185b0bfce5d" ApplicableType="IfcSpatialElement,IfcSpatialElementType,IfcTransportElement,IfcTransportElementType,IfcBuiltSystem,IfcDistributionSystem,IfcZone,IfcDoor" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
 	<Properties>
 		<DocProperty xsi:nil="true" href="ProcessItem_0yXM2dwTn71gpxHeftzbS" />
 		<DocProperty xsi:nil="true" href="ProcessCapacity_1lMQMfyaj8WukwZC4nXkfi" />


### PR DESCRIPTION
Relates to comments within #159 around capacity and flow information within `IfcDoor` Psets.

ProcessItem description adjusted to make it more generic for application on `IfcDoor` access control points within a Passenger system.