### PR TITLE
Correcting Body Constraint & errors in other geometry Identifiers

### DIFF
--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1UkWjFvcfBnAIEMj62xkyL" Name="IfcLabel" UniqueId="5eba0b4f-e66a-4bc4-a48e-5ad182eeef15">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedBrep Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1UkWjFvcfBnAIEMj62xkyL" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2xr07AesHEURJbUoLEub93" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2xr07AesHEURJbUoLEub93" Name="IfcLabel" UniqueId="bbd401ca-a364-4e79-b4e5-7b254ee25243">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Directrix Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3FUF2zSFv4zfFnp4K6hkha" Name="IfcLabel" UniqueId="cf78f0bd-70fe-44f6-93f1-cc4506aeeae4">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3FUF2zSFv4zfFnp4K6hkha" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept DiskSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3F1YmjDon4jRM6uDRVxmbm" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body AdvancedSwept Tapered Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3F1YmjDon4jRM6uDRVxmbm" Name="IfcLabel" UniqueId="cf062c2d-372c-44b5-b586-e0d6dfef0970">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2nTsBx4yb0wfI4IH_ymbNg" Name="IfcLabel" UniqueId="b17762fb-13c9-40ea-9484-491fbcc255ea">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/Body SectionedSolidHorizontal/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2nTsBx4yb0wfI4IH_ymbNg" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0bxYYH1cT4JgnrBLKIvlRt" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0bxYYH1cT4JgnrBLKIvlRt" Name="IfcLabel" UniqueId="25ee2891-0667-444e-ac75-2d5512e6f6f7">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body AdvancedSweptSolid Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Brep Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Brep Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0NvS67aXz6GRCVNxTS3KHd" Name="IfcLabel" UniqueId="17e5c187-921f-4641-b31f-5fb75c0d4467">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0NvS67aXz6GRCVNxTS3KHd" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Brep Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Brep Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body CSG Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body CSG Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3hk6tDijHBb9kDdQ0gEneU" Name="IfcLabel" UniqueId="ebb86dcd-b2d4-4b94-9b8d-9da02a3b1a1e">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3hk6tDijHBb9kDdQ0gEneU" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body CSG Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body CSG Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Clipping Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Clipping Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_18OMQXZHH5jfYNSKVeHrlZ" Name="IfcLabel" UniqueId="486166a1-8d14-45b6-9897-7147e8475be3">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_18OMQXZHH5jfYNSKVeHrlZ" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Clipping Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Clipping Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceModel Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceModel Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1mwKtkuxHEiBumF4EWg$Q4" Name="IfcLabel" UniqueId="70e94dee-e3b4-4eb0-be30-3c43a0abf684">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1mwKtkuxHEiBumF4EWg$Q4" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceModel Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceModel Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceOrSolidModel Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceOrSolidModel Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3toRJv9m9CWR7$xMNkBiHo" Name="IfcLabel" UniqueId="f7c9b4f9-2702-4c81-b1ff-ed65ee2ec472">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3toRJv9m9CWR7$xMNkBiHo" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceOrSolidModel Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SurfaceOrSolidModel Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid Composite Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid Composite Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2x2hYwuQX6uOhNn3koSNFY" Name="IfcLabel" UniqueId="bb0ab8ba-e1a8-46e1-8ad7-c43bb27173e2">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2x2hYwuQX6uOhNn3koSNFY" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid Composite Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid Composite Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid CompositeCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid CompositeCurve Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2_YEcdr_552PtKDN_9egiv" Name="IfcLabel" UniqueId="be88e9a7-d7e1-4509-9dd4-357f89a2ab39">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2_YEcdr_552PtKDN_9egiv" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid CompositeCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid CompositeCurve Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid ParameterizedProfile Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid ParameterizedProfile Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1AFpkghhb5SuG59NCRYsVq" Name="IfcLabel" UniqueId="4a3f3baa-aeb9-4573-8405-25731b8b67f4">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1AFpkghhb5SuG59NCRYsVq" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid ParameterizedProfile Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid ParameterizedProfile Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2vL2xVM5PBpxWcFNALICQa" Name="IfcLabel" UniqueId="b9542edf-5856-4bcf-b826-3d729548c6a4">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2vL2xVM5PBpxWcFNALICQa" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/Body SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body SweptSolid Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0mK5uyp8rEXgoATeRco6yQ" Name="IfcLabel" UniqueId="30505e3c-cc8d-4e86-ac8a-7686e6c86f1a">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0mK5uyp8rEXgoATeRco6yQ" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Tessellation Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1rHAI9l019nRQiQjcl10Wv" Name="IfcLabel" UniqueId="7544a489-bc00-49c5-b6ac-6ad9af040839">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1rHAI9l019nRQiQjcl10Wv" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Body Geometry/Body Tessellation Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Body" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Clearance Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Clearance Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2bS6aNWZfD8OcGjMq1JYjN" Name="IfcLabel" UniqueId="a5706917-823a-4d21-8990-b56d014e2b57">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2bS6aNWZfD8OcGjMq1JYjN" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Clearance" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Clearance Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Clearance Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Clearance" Description="Value=Clearance" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Clearance" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/CoG Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/CoG Geometry/DocTemplateDefinition.xml
@@ -18,12 +18,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2WXO2$3wL5jw64FsEwRwJb" Name="IfcLabel" UniqueId="a08580bf-0fa5-45b7-a184-3f63ba6fa4e5">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2WXO2$3wL5jw64FsEwRwJb" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="CoG" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/CoG Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/CoG Geometry/DocTemplateDefinition.xml
@@ -18,7 +18,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="CoG" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Lighting Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Lighting Geometry/DocTemplateDefinition.xml
@@ -16,18 +16,32 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Lighting" Description="Value=Lighting" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Lighting" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=LightSource" Description="Value=LightSource" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="LightSource" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Lighting Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Lighting Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3ndcjUQvL2rBlvf4VRzBhA" Name="IfcLabel" UniqueId="f19e6b5e-6b95-42d4-bbf9-a447dbf4baca">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3ndcjUQvL2rBlvf4VRzBhA" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Lighting" />
 															</Expression>
@@ -32,12 +32,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_101Gh41Wf869ZVr9dRrfp6" Name="IfcLabel" UniqueId="40050ac4-060a-4818-98df-d499dbd69cc6">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_101Gh41Wf869ZVr9dRrfp6" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="LightSource" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Profile" Description="Value=Profile" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Profile" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_2T_th0uujF6v6BmyoO_SoS" Name="IfcLabel" UniqueId="9dfb7ac0-e38b-4f1b-918b-c3cc98f9cc9c">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_2T_th0uujF6v6BmyoO_SoS" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Profile" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/Profile 3D Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/Profile 3D Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Profile" Description="Value=Profile" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Profile" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/Profile 3D Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Profile Geometry/Profile 3D Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_13DghnArf5nAPmnDskNN0j" Name="IfcLabel" UniqueId="4336aaf1-2b5a-45c4-a670-c4ddae5d702d">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_13DghnArf5nAPmnDskNN0j" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Profile" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/DocTemplateDefinition.xml
@@ -18,12 +18,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0XvtdbuyLDevVZBRdRt4pQ" Name="IfcLabel" UniqueId="21e779e5-e3c5-4da3-97e3-2db9dbdc4cda">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0XvtdbuyLDevVZBRdRt4pQ" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/DocTemplateDefinition.xml
@@ -18,9 +18,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleConstraint />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/Reference SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/Reference SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -18,12 +18,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1aJHxp4i11Lw95KiYSKhou" Name="IfcLabel" UniqueId="644d1ef3-12c0-4157-a245-52c89c52bcb8">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1aJHxp4i11Lw95KiYSKhou" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
 															</Expression>
@@ -34,12 +34,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_31RgYATWz6YeerDnqnpjKu" Name="IfcLabel" UniqueId="c16ea88a-760f-468a-8a35-371d31ced538">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_31RgYATWz6YeerDnqnpjKu" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="SweptSolid" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/Reference SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference SweptSolid Geometry/Reference SweptSolid PolyCurve Geometry/DocTemplateDefinition.xml
@@ -18,18 +18,32 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleConstraint />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleConstraint />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="SweptSolid" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference Tessellation Geometry/DocTemplateDefinition.xml
@@ -18,7 +18,18 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel" />
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+													<Rules>
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
+															</Expression>
+														</DocModelRuleConstraint>
+													</Rules>
+												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Reference Geometry/Reference Tessellation Geometry/DocTemplateDefinition.xml
@@ -18,12 +18,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3QeLQa0X18jvXRXg1RCv0w" Name="IfcLabel" UniqueId="daa156a4-0210-48b7-985b-86a05b33903a">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3QeLQa0X18jvXRXg1RCv0w" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Reference" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Surface" Description="Value=Surface" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_212pjtt2TCSe6Iuxau$YKd" Name="IfcLabel" UniqueId="810b3b77-dc27-4c72-8192-e3b938fe2527">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_212pjtt2TCSe6Iuxau$YKd" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface 3D Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface 3D Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Surface" Description="Value=Surface" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface 3D Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface 3D Geometry/DocTemplateDefinition.xml
@@ -16,12 +16,12 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0MITo$Ibv3$QN16lPTsG59" Name="IfcLabel" UniqueId="1649dcbf-4a5e-43fd-a5c1-1af65dd90149">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0MITo$Ibv3$QN16lPTsG59" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
@@ -16,9 +16,16 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Surface" Description="Value=Surface" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>
@@ -32,7 +39,7 @@
 																<Reference xsi:type="DocOpReference">
 																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0OoHEdBB6A7isr1gBliekX" />
 																</Reference>
-																<Value xsi:type="DocOpLiteral" Literal="&apos;Tessellation&apos;" />
+																<Value xsi:type="DocOpLiteral" Literal="Tessellation" />
 															</Expression>
 														</DocModelRuleConstraint>
 													</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_3nhg1pTfb5RxH4dqEltX18" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="Surface" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Surface Geometry/Surface Tessellation Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_3nhg1pTfb5RxH4dqEltX18" Name="IfcLabel" UniqueId="f1aea073-7699-456f-b444-9f43afde1048">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
@@ -21,7 +21,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1M7n93d4vFfBImqOHYmmE6" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="SurveyPoints" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
@@ -37,7 +37,7 @@
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">
 																<Reference xsi:type="DocOpReference">
-																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_1uuAQmF7v29RC11M7R2$Dk" />
 																</Reference>
 																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="GeometricCurveSet" />
 															</Expression>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
@@ -16,18 +16,32 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=SurveyPoints" Description="Value=SurveyPoints" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="SurveyPoints" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=GeometricCurveSet" Description="Value=GeometricCurveSet" />
+														<DocModelRuleConstraint>
+															<Expression xsi:type="DocOpStatement" Operation="compareequal">
+																<Reference xsi:type="DocOpReference">
+																	<EntityRule xsi:type="DocModelRuleEntity" xsi:nil="true" href="IfcLabel_0000000000000000000000" />
+																</Reference>
+																<Value xsi:type="DocOpLiteral" Operation="loadstring" Literal="GeometricCurveSet" />
+															</Expression>
+														</DocModelRuleConstraint>
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
@@ -32,7 +32,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute Name="RepresentationType" Identification="Type">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1uuAQmF7v29RC11M7R2$Dk" Name="IfcLabel" UniqueId="78e0a6b0-3c7e-4225-b301-0561db0bf36e">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Geometric Representation/Survey Points Geometry/DocTemplateDefinition.xml
@@ -16,7 +16,7 @@
 										</DocModelRuleAttribute>
 										<DocModelRuleAttribute CardinalityMin="1" CardinalityMax="1" Name="RepresentationIdentifier" Identification="Identifier">
 											<Rules>
-												<DocModelRuleEntity id="IfcLabel_0000000000000000000000" Name="IfcLabel">
+												<DocModelRuleEntity id="IfcLabel_1M7n93d4vFfBImqOHYmmE6" Name="IfcLabel" UniqueId="561f1243-9c4e-4fa4-b4b0-d18462c30386">
 													<Rules>
 														<DocModelRuleConstraint>
 															<Expression xsi:type="DocOpStatement" Operation="compareequal">

--- a/IFC4x3/Templates/Product Type Shape/Product Type Geometric Representation/Type Body Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Type Shape/Product Type Geometric Representation/Type Body Geometry/DocTemplateDefinition.xml
@@ -18,7 +18,7 @@
 											<Rules>
 												<DocModelRuleEntity Name="IfcLabel">
 													<Rules>
-														<DocModelRuleAttribute Name="Value=Body" Description="Value=Body" />
+														<DocModelRuleAttribute Name="Value=Body" />
 													</Rules>
 												</DocModelRuleEntity>
 											</Rules>


### PR DESCRIPTION
Fixes #252

adds missing Body representationIdentifier value constraints on child elements.
Discovered errors, inconsistancies and missing identifiers in other geometry CTs so addresses these.

I ran a local documentation generation an the updates fix the issues in the mvdXML and the diagrams