### PR TITLE
Remove Partial Template ModelRuleEntity duplication

### DIFF
--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Disk Solid Geometry/Swept Disk Solid PolyCurve Directrix/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Disk Solid Geometry/Swept Disk Solid PolyCurve Directrix/DocTemplateDefinition.xml
@@ -52,7 +52,6 @@
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/DocTemplateDefinition.xml
@@ -37,7 +37,6 @@
 		<DocModelRuleAttribute Name="SweptArea" Identification="Profile">
 			<Rules>
 				<DocModelRuleEntity Name="IfcProfileDef" />
-				<DocModelRuleEntity Name="IfcProfileDef" />
 			</Rules>
 		</DocModelRuleAttribute>
 		<DocModelRuleAttribute Name="StyledByItem">
@@ -47,12 +46,10 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
-								<DocModelRuleEntity Name="IfcLabel" />
 								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Basic Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Basic Profile/DocTemplateDefinition.xml
@@ -56,20 +56,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Composite Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Composite Profile/DocTemplateDefinition.xml
@@ -37,7 +37,6 @@
 		<DocModelRuleAttribute Name="SweptArea" Identification="Profile">
 			<Rules>
 				<DocModelRuleEntity Name="IfcProfileDef" />
-				<DocModelRuleEntity Name="IfcProfileDef" />
 				<DocModelRuleEntity Name="IfcCompositeProfileDef">
 					<References>
 						<DocTemplateDefinition xsi:nil="true" href="Composite_Profile_Definition_3WmGY8SU12S8FgOznP1LI_" />
@@ -52,12 +51,10 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
-								<DocModelRuleEntity Name="IfcLabel" />
 								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area CompositeCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area CompositeCurve Profile/DocTemplateDefinition.xml
@@ -51,20 +51,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area PolyCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area PolyCurve Profile/DocTemplateDefinition.xml
@@ -56,20 +56,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Standardized Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Geometry/Extruded Area Standardized Profile/DocTemplateDefinition.xml
@@ -57,20 +57,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Tapered Geometry/Extruded Area Tapered Parameterized Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Tapered Geometry/Extruded Area Tapered Parameterized Profile/DocTemplateDefinition.xml
@@ -48,18 +48,15 @@
 						<DocModelRuleAttribute Name="Location">
 							<Rules>
 								<DocModelRuleEntity Name="IfcCartesianPoint" />
-								<DocModelRuleEntity Name="IfcCartesianPoint" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Axis">
 							<Rules>
 								<DocModelRuleEntity Name="IfcDirection" />
-								<DocModelRuleEntity Name="IfcDirection" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="RefDirection">
 							<Rules>
-								<DocModelRuleEntity Name="IfcDirection" />
 								<DocModelRuleEntity Name="IfcDirection" />
 							</Rules>
 						</DocModelRuleAttribute>
@@ -71,19 +68,16 @@
 		<DocModelRuleAttribute Name="ExtrudedDirection">
 			<Rules>
 				<DocModelRuleEntity Name="IfcDirection" />
-				<DocModelRuleEntity Name="IfcDirection" />
 			</Rules>
 		</DocModelRuleAttribute>
 		<DocModelRuleAttribute Name="Depth">
 			<Rules>
-				<DocModelRuleEntity Name="IfcPositiveLengthMeasure" />
 				<DocModelRuleEntity Name="IfcPositiveLengthMeasure" />
 			</Rules>
 		</DocModelRuleAttribute>
 		<DocModelRuleAttribute Name="EndSweptArea">
 			<Rules>
 				<DocModelRuleEntity Name="IfcParameterizedProfileDef" />
-				<DocModelRuleEntity Name="IfcDerivedProfileDef" />
 			</Rules>
 		</DocModelRuleAttribute>
 	</Rules>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Tapered Geometry/Extruded Area Tapered PolyCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Extruded Area Tapered Geometry/Extruded Area Tapered PolyCurve Profile/DocTemplateDefinition.xml
@@ -44,18 +44,15 @@
 						<DocModelRuleAttribute Name="Location">
 							<Rules>
 								<DocModelRuleEntity Name="IfcCartesianPoint" />
-								<DocModelRuleEntity Name="IfcCartesianPoint" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Axis">
 							<Rules>
 								<DocModelRuleEntity Name="IfcDirection" />
-								<DocModelRuleEntity Name="IfcDirection" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="RefDirection">
 							<Rules>
-								<DocModelRuleEntity Name="IfcDirection" />
 								<DocModelRuleEntity Name="IfcDirection" />
 							</Rules>
 						</DocModelRuleAttribute>
@@ -67,12 +64,10 @@
 		<DocModelRuleAttribute Name="ExtrudedDirection">
 			<Rules>
 				<DocModelRuleEntity Name="IfcDirection" />
-				<DocModelRuleEntity Name="IfcDirection" />
 			</Rules>
 		</DocModelRuleAttribute>
 		<DocModelRuleAttribute Name="Depth">
 			<Rules>
-				<DocModelRuleEntity Name="IfcPositiveLengthMeasure" />
 				<DocModelRuleEntity Name="IfcPositiveLengthMeasure" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/FixedReference SweptArea Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/FixedReference SweptArea Geometry/DocTemplateDefinition.xml
@@ -39,12 +39,10 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
-								<DocModelRuleEntity Name="IfcLabel" />
 								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/FixedReference SweptArea Geometry/FixedReference SweptArea PolyCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/FixedReference SweptArea Geometry/FixedReference SweptArea PolyCurve Profile/DocTemplateDefinition.xml
@@ -43,20 +43,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/DocTemplateDefinition.xml
@@ -37,7 +37,6 @@
 		<DocModelRuleAttribute Name="SweptArea" Identification="Profile">
 			<Rules>
 				<DocModelRuleEntity Name="IfcProfileDef" />
-				<DocModelRuleEntity Name="IfcProfileDef" />
 			</Rules>
 		</DocModelRuleAttribute>
 		<DocModelRuleAttribute Name="StyledByItem">
@@ -47,12 +46,10 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
-								<DocModelRuleEntity Name="IfcLabel" />
 								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area Basic Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area Basic Profile/DocTemplateDefinition.xml
@@ -56,20 +56,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area CompositeCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area CompositeCurve Profile/DocTemplateDefinition.xml
@@ -64,20 +64,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area PolyCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area PolyCurve Profile/DocTemplateDefinition.xml
@@ -64,20 +64,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area Standardized Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/Revolved Area Geometry/Revolved Area Standardized Profile/DocTemplateDefinition.xml
@@ -57,20 +57,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/SurfaceCurve SweptArea Geometry/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/SurfaceCurve SweptArea Geometry/DocTemplateDefinition.xml
@@ -40,12 +40,10 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
-								<DocModelRuleEntity Name="IfcLabel" />
 								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>

--- a/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/SurfaceCurve SweptArea Geometry/SurfaceCurve SweptArea PolyCurve Profile/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Geometry/Solid Model Geometry/Swept Solid Geometry/SurfaceCurve SweptArea Geometry/SurfaceCurve SweptArea PolyCurve Profile/DocTemplateDefinition.xml
@@ -44,20 +44,15 @@
 						<DocModelRuleAttribute Name="Styles">
 							<Rules>
 								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
-								<DocModelRuleEntity Name="IfcSurfaceStyle" />
 							</Rules>
 						</DocModelRuleAttribute>
 						<DocModelRuleAttribute Name="Name">
 							<Rules>
 								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
-								<DocModelRuleEntity Name="IfcLabel" />
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>
 				</DocModelRuleEntity>
-				<DocModelRuleEntity Name="IfcStyledItem" />
 				<DocModelRuleEntity Name="IfcStyledItem" />
 			</Rules>
 		</DocModelRuleAttribute>


### PR DESCRIPTION
I've taken a look at some duplication of DocModelRuleEntity within partial templates.
I can't ascertain exactly when and why this happened, I believe they are inherited from original baselines.
I've manually removed the duplication I identified in this pull request.