### PR TITLE
Moving & Renaming Alignment

### DIFF
--- a/IFC4x3/ModelViews/General Usage/DocModelView.xml
+++ b/IFC4x3/ModelViews/General Usage/DocModelView.xml
@@ -507,7 +507,7 @@ The **IfcActionRequest** may have assignments of its own using the [IfcRelAssign
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAlignment" />
 			<Concepts>
 				<DocTemplateUsage Name="Alignment Decomposition" UniqueId="e554c63e-acc9-473f-9469-6124fef84b4a">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Alignment_Decomposition_0pJdzdMb6NxCKeW4AcNHb" />
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Alignment_Layout_0pJdzdMb6NxCKeW4AcNHb" />
 					<Items>
 						<DocTemplateItem UniqueId="b141e610-0b3c-4d9b-9dbb-f53827904de3" />
 					</Items>

--- a/IFC4x3/ModelViews/General Usage/DocModelView.xml
+++ b/IFC4x3/ModelViews/General Usage/DocModelView.xml
@@ -506,7 +506,7 @@ The **IfcActionRequest** may have assignments of its own using the [IfcRelAssign
 		<DocConceptRoot UniqueId="733a949d-1cc8-4d40-bd6a-3836e3c195dd">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAlignment" />
 			<Concepts>
-				<DocTemplateUsage Name="Alignment Decomposition" UniqueId="e554c63e-acc9-473f-9469-6124fef84b4a">
+				<DocTemplateUsage Name="Alignment Layout" UniqueId="e554c63e-acc9-473f-9469-6124fef84b4a">
 					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Alignment_Layout_0pJdzdMb6NxCKeW4AcNHb" />
 					<Items>
 						<DocTemplateItem UniqueId="b141e610-0b3c-4d9b-9dbb-f53827904de3" />

--- a/IFC4x3/Templates/Object Composition/Nesting/Alignment Layout/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Composition/Nesting/Alignment Layout/DocTemplateDefinition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Alignment_Decomposition_0pJdzdMb6NxCKeW4AcNHb" Name="Alignment Decomposition" UniqueId="334e7f67-fd69-465f-b314-a2010a997465" Type="IfcAlignment">
+<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Alignment_Layout_0pJdzdMb6NxCKeW4AcNHb" Name="Alignment Layout" UniqueId="334e7f67-fd69-465f-b314-a2010a997465" Type="IfcAlignment">
 	<Rules>
 		<DocModelRuleAttribute Name="IsNestedBy">
 			<Rules>


### PR DESCRIPTION
Moving Alignment to be under Nesting (it uses IfcRelNests) the correct catagorisation, and renaming as agreed at previous sprint meetings to Alignment Layout

Fixes #226
