### PR TITLE
Add RuleID Unit to Single Value partial template

### DIFF
--- a/IFC4x3/Templates/Partial Templates/Values/Single Value/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Values/Single Value/DocTemplateDefinition.xml
@@ -16,6 +16,11 @@
 				<DocModelRuleEntity Name="IfcValue" />
 			</Rules>
 		</DocModelRuleAttribute>
+		<DocModelRuleAttribute Name="Unit" Identification="Unit">
+			<Rules>
+				<DocModelRuleEntity Name="IfcUnit" />
+			</Rules>
+		</DocModelRuleAttribute>
 	</Rules>
 </DocTemplateDefinition>
 


### PR DESCRIPTION
Fixes #310 

Changes:
- The requirement from FMH-EM was to be able to check units on Single Value Properties.