### PR TITLE
Issue#435-in-IFC4.3.x-development

### DIFF
--- a/IFC4x3/Constants/n/NOTDEFINED_0KREE05HjEJhXkg0TpVYn8.xml
+++ b/IFC4x3/Constants/n/NOTDEFINED_0KREE05HjEJhXkg0TpVYn8.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="NOTDEFINED_0KREE05HjEJhXkg0TpVYn8" Name="NOTDEFINED" UniqueId="146ce380-151b-4e4e-b86e-a807737e2c48">
+	<Documentation>Undefined type.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Constants/u/USERDEFINED_1EjRgfc5r7bxjPir$f3y1X.xml
+++ b/IFC4x3/Constants/u/USERDEFINED_1EjRgfc5r7bxjPir$f3y1X.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="USERDEFINED_1EjRgfc5r7bxjPirf3y1X" Name="USERDEFINED" UniqueId="4eb5baa9-985d-4797-bb59-b35fe90fc061">
+	<Documentation>User-defined type.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Properties/i/IsMountable_0nASgQh6r2huzTgAp_avpJ/DocProperty.xml
+++ b/IFC4x3/Properties/i/IsMountable_0nASgQh6r2huzTgAp_avpJ/DocProperty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IsMountable_0nASgQh6r2huzTgAp_avpJ" Name="IsMountable" UniqueId="3129ca9a-ac6d-42af-8f5d-a8acfe939cd3" PrimaryDataType="IfcBoolean" />
+

--- a/IFC4x3/Properties/i/IsMountable_0nASgQh6r2huzTgAp_avpJ/Documentation.md
+++ b/IFC4x3/Properties/i/IsMountable_0nASgQh6r2huzTgAp_avpJ/Documentation.md
@@ -1,0 +1,1 @@
+Specifies whether the kerb can be readily climbed by a vehicle or not.

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
@@ -8,7 +8,7 @@ NOTE  The PredefinedType shall only be used, if no IfcKerbType is assigned, prov
 	</Attributes>
 	<WhereRules>
 		<DocWhereRule Name="CorrectPredefinedType" UniqueId="1718650a-cf53-4936-a174-a80356ecc357">
-			<Documentation>Either the _PredefinedType_ attribute is unset(e.g. because an _IfcKerbType_ is associated), or the inherited attribute _ObjectType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
+			<Documentation>Either the _PredefinedType_ attribute is unset (e.g. because an _IfcKerbType_ is associated), or the inherited attribute _ObjectType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
 			<Expression>NOT(EXISTS(PredefinedType)) OR
 (PredefinedType &lt;&gt; IfcKerbTypeEnum.USERDEFINED) OR
 ((PredefinedType = IfcKerbTypeEnum.USERDEFINED) AND EXISTS(SELF\IfcObject.ObjectType))</Expression>

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcKerb" UniqueId="5f9cc447-6ed4-41b3-9201-7db99ef32744" BaseDefinition="IfcBuiltElement" EntityFlags="32">
 	<Attributes>
-		<DocAttribute Name="Mountable" UniqueId="58b5766a-263f-4dab-abdc-8c10cd3f43de" DefinedType="IfcBoolean">
-			<Documentation>Specifies whether the kerb can be readily climbed by a vehicle or not.</Documentation>
+		<DocAttribute Name="PredefinedType" UniqueId="17ec7cf6-475d-43b2-ba7e-f765ae319696" DefinedType="IfcKerbTypeEnum" AttributeFlags="1">
+			<Documentation>Identifies the predefined type of a kerb element. This type may associate additional specific property sets.
+NOTE  The PredefinedType shall only be used, if no IfcKerbType is assigned, providing its own IfcKerbType.PredefinedType.</Documentation>
 		</DocAttribute>
 	</Attributes>
+	<WhereRules>
+		<DocWhereRule Name="CorrectPredefinedType" UniqueId="1718650a-cf53-4936-a174-a80356ecc357">
+			<Documentation>Either the _PredefinedType_ attribute is unset(e.g. because an _IfcKerbType_ is associated), or the inherited attribute _ObjectType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
+			<Expression>NOT(EXISTS(PredefinedType)) OR
+(PredefinedType &lt;&gt; IfcKerbTypeEnum.USERDEFINED) OR
+((PredefinedType = IfcKerbTypeEnum.USERDEFINED) AND EXISTS(SELF\IfcObject.ObjectType))</Expression>
+		</DocWhereRule>
+		<DocWhereRule Name="CorrectTypeAssigned" UniqueId="e1621848-8c2d-44aa-a3aa-5b7fba799a6a">
+			<Documentation>Either there is no type object associated, i.e. the _IsTypedBy_ inverse relationship is not provided, or the associated type object has to be of type _IfcKerbType_.</Documentation>
+			<Expression>(SIZEOF(IsTypedBy) = 0) OR
+(&apos;IFCROADDOMAIN.IFCKERBTYPE&apos; IN TYPEOF(SELF\IfcObject.IsTypedBy[1].RelatingType))</Expression>
+		</DocWhereRule>
+	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerb/DocEntity.xml
@@ -3,7 +3,7 @@
 	<Attributes>
 		<DocAttribute Name="PredefinedType" UniqueId="17ec7cf6-475d-43b2-ba7e-f765ae319696" DefinedType="IfcKerbTypeEnum" AttributeFlags="1">
 			<Documentation>Identifies the predefined type of a kerb element. This type may associate additional specific property sets.
-NOTE  The PredefinedType shall only be used, if no IfcKerbType is assigned, providing its own IfcKerbType.PredefinedType.</Documentation>
+>NOTE  The PredefinedType shall only be used, if no IfcKerbType is assigned, providing its own IfcKerbType.PredefinedType.</Documentation>
 		</DocAttribute>
 	</Attributes>
 	<WhereRules>

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerbType/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerbType/DocEntity.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcKerbType" UniqueId="83a82066-49a2-47f3-90d7-c84f0767f190" BaseDefinition="IfcBuiltElementType" EntityFlags="32">
 	<Attributes>
-		<DocAttribute Name="Mountable" UniqueId="cbb2c493-5a1b-4c09-a204-435e8a5d00dc" DefinedType="IfcBoolean">
-			<Documentation>Specifies whether the kerb can be readily climbed by a vehicle or not.</Documentation>
+		<DocAttribute Name="PredefinedType" UniqueId="cc710e07-9f14-4252-a2d3-ea0dcbc1e024" DefinedType="IfcKerbTypeEnum">
+			<Documentation>Identifies the predefined type of a kerb element.</Documentation>
 		</DocAttribute>
 	</Attributes>
+	<WhereRules>
+		<DocWhereRule Name="CorrectPredefinedType" UniqueId="93d97cf8-ba87-4e11-b07f-f5122973b687">
+			<Documentation>The inherited attribute _ElementType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
+			<Expression>(PredefinedType &lt;&gt; IfcKerbTypeEnum.USERDEFINED) OR
+((PredefinedType = IfcKerbTypeEnum.USERDEFINED) AND EXISTS(SELF\IfcElementType.ElementType))</Expression>
+		</DocWhereRule>
+	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerbType/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Entities/IfcKerbType/DocEntity.xml
@@ -7,7 +7,7 @@
 	</Attributes>
 	<WhereRules>
 		<DocWhereRule Name="CorrectPredefinedType" UniqueId="93d97cf8-ba87-4e11-b07f-f5122973b687">
-			<Documentation>The inherited attribute _ElementType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
+			<Documentation>The inherited attribute _ObjectType_ shall be provided, if the _PredefinedType_ is set to USERDEFINED.</Documentation>
 			<Expression>(PredefinedType &lt;&gt; IfcKerbTypeEnum.USERDEFINED) OR
 ((PredefinedType = IfcKerbTypeEnum.USERDEFINED) AND EXISTS(SELF\IfcElementType.ElementType))</Expression>
 		</DocWhereRule>

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/PropertySets/Pset_KerbCommon/DocPropertySet.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/PropertySets/Pset_KerbCommon/DocPropertySet.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_KerbCommon" UniqueId="0c6dd572-b9b4-424c-94e6-454d24d56fb7" ApplicableType="IfcKerb" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_KerbCommon" UniqueId="0c6dd572-b9b4-424c-94e6-454d24d56fb7" ApplicableType="IfcKerb,IfcKerbType" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
 	<Properties>
 		<DocProperty xsi:nil="true" href="CombinedKerbGutter_2XVviYqS9BKeFimfQfNm7U" />
 		<DocProperty xsi:nil="true" href="Upstand_3VCJVzwh9CCfDp_58_XB7_" />
+		<DocProperty xsi:nil="true" href="IsMountable_0nASgQh6r2huzTgAp_avpJ" />
 	</Properties>
 </DocPropertySet>
 

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Types/IfcKerbTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRoadDomain/Types/IfcKerbTypeEnum/DocEnumeration.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocEnumeration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcKerbTypeEnum" UniqueId="7052921f-5cc7-477b-a924-d7c001c0a2f6">
+	<Constants>
+		<DocConstant xsi:nil="true" href="USERDEFINED_1EjRgfc5r7bxjPirf3y1X" />
+		<DocConstant xsi:nil="true" href="NOTDEFINED_0KREE05HjEJhXkg0TpVYn8" />
+	</Constants>
+</DocEnumeration>
+


### PR DESCRIPTION
- Remove IfcKerb/IfcKerbType.Mountable
- Add IsMountable : IfcBoolean to Pset_KerbCommon
- PSet_KerbCommon applicability fixed (both IfcKerb and IfcKerbType)
- Added Enumeration IfcKerbTypeEnum {USERDEFINED, NOTDEFINED}
- Added PredefinedType : IfcKerbTypeEnum to IfcKerb and IfcKerbType
- Added where-rules CorrectPredefinedType and CorrectType assigned to IfcKerb
- Added where-rule CorrectPredefinedType to IfcKerbType

Fixes https://github.com/buildingSMART/IFC4.3.x-development/issues/435