### PR TITLE
RAILWAYTRACK and RAILWAYLINE + pset association issue 305

### DIFF
--- a/IFC4x3/Constants/r/RAILWAYLINE_0EI3QpV6rCqe7ljBV9Ekx8.xml
+++ b/IFC4x3/Constants/r/RAILWAYLINE_0EI3QpV6rCqe7ljBV9Ekx8.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RAILWAYLINE_0EI3QpV6rCqe7ljBV9Ekx8" Name="RAILWAYLINE" UniqueId="0e4836b3-7c6d-4cd2-81ef-b4b7c93aeec8">
+	<Documentation>A set of functional tracks with explicit terminals. It is usually composed of a set of tracks with continuous track parts and alignments.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Constants/r/RAILWAYTRACK_2DycPctdT8NA$DjgQd0dgt.xml
+++ b/IFC4x3/Constants/r/RAILWAYTRACK_2DycPctdT8NA$DjgQd0dgt.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="RAILWAYTRACK_2DycPctdT8NADjgQd0dgt" Name="RAILWAYTRACK" UniqueId="8df26666-de77-485c-afcd-b6a6a7027ab7">
+	<Documentation>Railway track system. It is usually composed of continuous sequences of track parts and alignments.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcBuiltSystemTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcBuiltSystemTypeEnum/DocEnumeration.xml
@@ -12,6 +12,8 @@
 		<DocConstant xsi:nil="true" href="FENESTRATION_2QETJRZ6P0G8P7HGcRHULe" />
 		<DocConstant xsi:nil="true" href="TRANSPORT_2T1Cc0KKj2TPPRHbZV_4lt" />
 		<DocConstant xsi:nil="true" href="PRESTRESSING_0WjCg2NvDlRkFEjxezo0a" />
+		<DocConstant xsi:nil="true" href="RAILWAYLINE_0EI3QpV6rCqe7ljBV9Ekx8" />
+		<DocConstant xsi:nil="true" href="RAILWAYTRACK_2DycPctdT8NADjgQd0dgt" />
 		<DocConstant xsi:nil="true" href="USERDEFINED_3UZXzKKD12RotG6dmTF8v" />
 		<DocConstant xsi:nil="true" href="NOTDEFINED_0hF15nkf79uy7wMtnpxz" />
 	</Constants>

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayLine/DocPropertySet.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayLine/DocPropertySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_BuiltSystemRailwayLine" UniqueId="89bf9f19-0b66-4d12-a7df-efdb44571f05" ApplicableType="IfcBuiltSystem/USERDEFINED" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_BuiltSystemRailwayLine" UniqueId="89bf9f19-0b66-4d12-a7df-efdb44571f05" ApplicableType="IfcBuiltSystem/RAILWAYLINE" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
 	<Properties>
 		<DocProperty xsi:nil="true" href="LineID_1LQ0XPbITCVe8zQJfs9vuz" />
 		<DocProperty xsi:nil="true" href="IsElectrified_3fjp6BiNH8WQOXnO69XO80" />

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayLine/Documentation.md
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayLine/Documentation.md
@@ -1,2 +1,1 @@
 Properties common to the definition of a railway line system, which is a set of functional tracks with explicit terminals. It is usually composed of a set of tracks with continuous track parts and alignments.
-> NOTE `IfcBuiltSystem.ObjectType` should be set to `RAILWAYLINE`

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayTrack/DocPropertySet.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayTrack/DocPropertySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_BuiltSystemTrack" UniqueId="d94faf14-a0d4-d78f-e785-79994ced445d" ApplicableType="IfcBuiltSystem/USERDEFINED" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_BuiltSystemRailwayTrack" UniqueId="d94faf14-a0d4-d78f-e785-79994ced445d" ApplicableType="IfcBuiltSystem/RAILWAYTRACK" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
 	<Properties>
 		<DocProperty xsi:nil="true" href="TrackID_1QUq47Cd5EufPArQiLv0RG" />
 		<DocProperty xsi:nil="true" href="TrackNumber_04f6CUpMXA8hZooEXNRWkz" />

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayTrack/Documentation.md
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcRailDomain/PropertySets/Pset_BuiltSystemRailwayTrack/Documentation.md
@@ -1,2 +1,1 @@
 Properties common to the definition of a track system. It is usually composed of continuous sequences of track parts and alignments.
-> NOTE `IfcBuiltSystem.ObjectType` should be set to `TRACK`


### PR DESCRIPTION
1. Added `IfcBuiltSystemTypeEnum.RAILWAYTRACK` and `IfcBuiltSystemTypeEnum.RAILWAYLINE` and documentation
2. Fixed applicability of related psets and documentation
3. Renamed `Pset_BuiltSystemTrack` to `Pset_BuiltSystemRailwayTrack`

Since I was at it, I also fixed the psets in this issue.