### PR TITLE
Associate qsets without applicability issue 281

### DIFF
--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_CourseBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_CourseBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_CourseBaseQuantities" UniqueId="b3269da3-f658-4a62-9cb4-72d0d173143f">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_CourseBaseQuantities" UniqueId="b3269da3-f658-4a62-9cb4-72d0d173143f" ApplicableType="IfcCourse">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_EarthworksCutBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_EarthworksCutBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_EarthworksCutBaseQuantities" UniqueId="7664b932-a766-4552-b766-9c2c18a60d97">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_EarthworksCutBaseQuantities" UniqueId="7664b932-a766-4552-b766-9c2c18a60d97" ApplicableType="IfcEarthworksCut">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_EarthworksFillBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_EarthworksFillBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_EarthworksFillBaseQuantities" UniqueId="f5e94a6c-6ac4-45a9-8590-fbff8c6ba311">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_EarthworksFillBaseQuantities" UniqueId="f5e94a6c-6ac4-45a9-8590-fbff8c6ba311" ApplicableType="IfcEarthworksFill">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ImpactProtectionDeviceBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ImpactProtectionDeviceBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_ImpactProtectionDeviceBaseQuantities" UniqueId="4edbaef5-6f65-4131-a5b8-1772029277a8">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_ImpactProtectionDeviceBaseQuantities" UniqueId="4edbaef5-6f65-4131-a5b8-1772029277a8" ApplicableType="IfcImpactProtectionDevice">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Weight_2ueoe8QyrBduWuJHsi21zb" />
 	</Quantities>

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_KerbBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_KerbBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_KerbBaseQuantities" UniqueId="36a5c107-d1d3-4cfb-8e52-c0ff2fae553d">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_KerbBaseQuantities" UniqueId="36a5c107-d1d3-4cfb-8e52-c0ff2fae553d" ApplicableType="IfcKerb">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_PavementBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_PavementBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_PavementBaseQuantities" UniqueId="7a9957b6-dadf-4dec-bd43-a8f4beca15d3">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_PavementBaseQuantities" UniqueId="7a9957b6-dadf-4dec-bd43-a8f4beca15d3" ApplicableType="IfcPavement">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_PictorialSignQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_PictorialSignQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_PictorialSignQuantities" UniqueId="c0785096-718a-459d-8ae8-b76089be6d06">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_PictorialSignQuantities" UniqueId="c0785096-718a-459d-8ae8-b76089be6d06" ApplicableType="IfcSign/PICTORAL">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Area_1CnNsFYBT6AemE3IaDxL7" />
 		<DocQuantity xsi:nil="true" href="SignArea_32i2POqiz7sxewNKXzANau" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ReinforcedSoilBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ReinforcedSoilBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_ReinforcedSoilBaseQuantities" UniqueId="d4fc872b-f7f9-4eef-8927-dea31fe06111">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_ReinforcedSoilBaseQuantities" UniqueId="d4fc872b-f7f9-4eef-8927-dea31fe06111" ApplicableType="IfcReinforcedSoil">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SignBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SignBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SignBaseQuantities" UniqueId="fb485ee8-9c7e-46ca-9d0f-eac5dfd7aa41">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SignBaseQuantities" UniqueId="fb485ee8-9c7e-46ca-9d0f-eac5dfd7aa41" ApplicableType="IfcSign">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Height_3jq0d8r0zBYvccpej6okcm" />
 		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SignalBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SignalBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SignalBaseQuantities" UniqueId="b02c9d87-835c-43bb-bedb-7b4a65013060">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SignalBaseQuantities" UniqueId="b02c9d87-835c-43bb-bedb-7b4a65013060" ApplicableType="IfcSignal">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Weight_2ueoe8QyrBduWuJHsi21zb" />
 	</Quantities>

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SurfaceFeatureBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_SurfaceFeatureBaseQuantities/DocQuantitySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SurfaceFeatureBaseQuantities" UniqueId="0e448c2d-3d73-4cce-b2d4-e5d9eddb3ed6">
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_SurfaceFeatureBaseQuantities" UniqueId="0e448c2d-3d73-4cce-b2d4-e5d9eddb3ed6" ApplicableType="IfcSurfaceFeature">
 	<Quantities>
 		<DocQuantity xsi:nil="true" href="Area_1CnNsFYBT6AemE3IaDxL7" />
 		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />


### PR DESCRIPTION
Added applicabilities for;
1. Qto_CourseBaseQuantities
2. Qto_EarthworksCutBaseQuantities
3. Qto_EarthworksFillBaseQuantities
4. Qto_ImpactProtectionDeviceBaseQuantities
5. Qto_KerbBaseQuantities
6. Qto_PavementBaseQuantities
7. Qto_PictorialSignQuantities
8. Qto_ReinforcedSoilBaseQuantities
9. Qto_SignBaseQuantities
10. Qto_SignalBaseQuantities
11. Qto_SurfaceFeatureBaseQuantities

Others were already present.