### PR TITLE
Feature/ifc virtual element

### DIFF
--- a/IFC4x3/Constants/b/BOUNDARY_0D9uazImf8vO$PVKzXao_2.xml
+++ b/IFC4x3/Constants/b/BOUNDARY_0D9uazImf8vO$PVKzXao_2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="BOUNDARY_0D9uazImf8vOPVKzXao_2" Name="BOUNDARY" UniqueId="0d27893d-4b0a-48e5-8fd9-7d4f61932f82">
+	<Documentation>An imaginary boundary, such as between two adjacent spaces that are not separated by a physcial boundary.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Constants/c/CLEARANCE_0hS5MhQVv57hIehqvLOgZ9.xml
+++ b/IFC4x3/Constants/c/CLEARANCE_0hS5MhQVv57hIehqvLOgZ9.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="CLEARANCE_0hS5MhQVv57hIehqvLOgZ9" Name="CLEARANCE" UniqueId="2b7055ab-69fe-451e-b4a8-af4e5562a8c9">
-	<Documentation>The virtual element denotes a clearance area or volume
+	<Documentation>The virtual element denotes a clearance area or volume.
 
 &gt;EXAMPLE The space allocated as a placeholder for mechanical equipment or furniture.</Documentation>
 </DocConstant>

--- a/IFC4x3/Constants/c/CLEARANCE_0hS5MhQVv57hIehqvLOgZ9.xml
+++ b/IFC4x3/Constants/c/CLEARANCE_0hS5MhQVv57hIehqvLOgZ9.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocConstant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="CLEARANCE_0hS5MhQVv57hIehqvLOgZ9" Name="CLEARANCE" UniqueId="2b7055ab-69fe-451e-b4a8-af4e5562a8c9">
+	<Documentation>The virtual element denotes a clearance area or volume
+
+&gt;EXAMPLE The space allocated as a placeholder for mechanical equipment or furniture.</Documentation>
+</DocConstant>
+

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVirtualElement/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVirtualElement/DocEntity.xml
@@ -5,5 +5,12 @@
 		<DocLocalization Locale="en" Name="Virtual Element" />
 		<DocLocalization Locale="fr" Name="Élément virtuel" />
 	</Localization>
+	<Attributes>
+		<DocAttribute Name="PredefinedType" UniqueId="89972bc8-05b7-43af-8ade-b8ac3769243a" DefinedType="IfcVirtualElementTypeEnum">
+			<Definition>
+				<DocEnumeration xsi:nil="true" href="IfcVirtualElementTypeEnum" />
+			</Definition>
+		</DocAttribute>
+	</Attributes>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcVirtualElementTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcVirtualElementTypeEnum/DocEnumeration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocEnumeration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcVirtualElementTypeEnum" Name="IfcVirtualElementTypeEnum" UniqueId="a28fdf84-8ede-44bd-96ea-b74c66ca5c64" DiagramNumber="1">
+	<DiagramRectangle xsi:type="DocRectangle" X="0" Y="0" Width="400" Height="100" />
+	<Constants>
+		<DocConstant xsi:nil="true" href="BOUNDARY_0D9uazImf8vOPVKzXao_2" />
+		<DocConstant xsi:nil="true" href="CLEARANCE_0hS5MhQVv57hIehqvLOgZ9" />
+		<DocConstant xsi:nil="true" href="PROVISIONFORVOID_2vF_Yr7J92wvfWU_bCEDv" />
+		<DocConstant xsi:nil="true" href="USERDEFINED_0_qB1IzZj7e9Sm743ClEtS" />
+		<DocConstant xsi:nil="true" href="NOTDEFINED_0hF15nkf79uy7wMtnpxz" />
+	</Constants>
+</DocEnumeration>
+

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcVirtualElementTypeEnum/Documentation.md
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Types/IfcVirtualElementTypeEnum/Documentation.md
@@ -1,0 +1,1 @@
+Enumeration of Virtual Element Types.


### PR DESCRIPTION
1. added `IfcVirtualElementTypeEnum` and documentation
2. added `PredefinedType` to `IfcVirtualElement`

I have not added the documentation for `PredefinedType` because it is misleading due not not having an `IfcTypeObject` for `IfcVirtualElement`. For the same reason I have not added the WR `CorrectPredefinedType`. Shall we make it consistent?