### PR TITLE
Feature/closed attribute on supertype

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/DocSchema.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/DocSchema.xml
@@ -34,7 +34,7 @@
 				<DocDefinitionRef Name="IfcPlaneAngleMeasure" UniqueId="bdcf7f14-63da-4066-aa16-d68a69f41bc5" />
 				<DocDefinitionRef Name="IfcParameterValue" UniqueId="a3512312-a856-49a0-81ae-f9133eebaf2c" />
 				<DocDefinitionRef Name="IfcLengthMeasure" UniqueId="3c831c12-d959-431b-acb3-ead5264dd715" />
-				<DocDefinitionRef Name="IfcBoolean" UniqueId="5846255f-c88f-4014-be92-a94d7a3d3c39" />
+				<DocDefinitionRef id="IfcBoolean_1OHYLVo8z05BwIgKrwFJmv" Name="IfcBoolean" UniqueId="5846255f-c88f-4014-be92-a94d7a3d3c39" />
 				<DocDefinitionRef Name="IfcInteger" UniqueId="10de1fa3-b124-4d41-84fa-113459d99491" />
 				<DocDefinitionRef Name="IfcPositiveInteger" UniqueId="6b5c4b68-240e-438f-a05a-e1305da435ec" />
 				<DocDefinitionRef Name="IfcLabel" UniqueId="07fd9c74-8190-4dc9-bee0-d244ed13b0f8" />

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcPolygonalFaceSet/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcPolygonalFaceSet/DocEntity.xml
@@ -4,9 +4,6 @@
 		<DocLocalization Locale="en" Name="Polygonal Face Set" />
 	</Localization>
 	<Attributes>
-		<DocAttribute Name="Closed" UniqueId="6f54d305-9e4f-48f6-802b-83d293cd932e" DefinedType="IfcBoolean" AttributeFlags="1">
-			<Documentation>Indication whether the _IfcPolygonalFaceSet_ is a closed shell or not. If omited no such information can be provided.</Documentation>
-		</DocAttribute>
 		<DocAttribute Name="Faces" UniqueId="ce73f034-79d3-4e8d-a2df-68e051c2606b" DefinedType="IfcIndexedPolygonalFace" AggregationType="1" AggregationLower="1" AggregationUpper="?">
 			<Documentation>The list of polygonal faces, with or without inner loops, that bound the faceted face set.</Documentation>
 		</DocAttribute>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
@@ -14,6 +14,12 @@
 		<DocAttribute Name="Coordinates" UniqueId="28b00035-2a37-4bda-aa0e-7845352fa060" DefinedType="IfcCartesianPointList3D" XsdFormat="attribute">
 			<Documentation>An ordered list of Cartesian points used by the coordinate index defined at the subtypes of _IfcTessellatedFaceSet_.</Documentation>
 		</DocAttribute>
+		<DocAttribute Name="Closed" UniqueId="0ed95f80-d2a4-4366-9e14-879da9de6926" DefinedType="IfcBoolean">
+			<Documentation>Indication whether the _IfcPolygonalFaceSet_ is a closed shell or not. If omited no such information can be provided.</Documentation>
+			<Definition>
+				<DocDefinitionRef xsi:nil="true" href="IfcBoolean_1OHYLVo8z05BwIgKrwFJmv" />
+			</Definition>
+		</DocAttribute>
 		<DocAttribute Name="Dim" UniqueId="43876eff-5b1f-4247-b220-0e835e3f5f0e" DefinedType="IfcDimensionCount">
 			<Documentation>The space dimensionality of this geometric representation item, it is always 3.</Documentation>
 			<Derived>3</Derived>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
@@ -15,7 +15,7 @@
 			<Documentation>An ordered list of Cartesian points used by the coordinate index defined at the subtypes of _IfcTessellatedFaceSet_.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="Closed" UniqueId="0ed95f80-d2a4-4366-9e14-879da9de6926" DefinedType="IfcBoolean">
-			<Documentation>Indication whether the _IfcPolygonalFaceSet_ is a closed shell or not. If omited no such information can be provided.</Documentation>
+			<Documentation>Indication whether the _IfcTessellatedFaceSet_ is a closed shell or not. If omitted no such information can be provided.</Documentation>
 			<Definition>
 				<DocDefinitionRef xsi:nil="true" href="IfcBoolean_1OHYLVo8z05BwIgKrwFJmv" />
 			</Definition>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTriangulatedFaceSet/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTriangulatedFaceSet/DocEntity.xml
@@ -16,9 +16,6 @@ values.
 * The second dimension has exactly three values, [1] the x-direction, [2] the y-direction and [3] the z-directions</Documentation>
 			<AggregationAttribute xsi:type="DocAttribute" UniqueId="35164181-c3c4-4f4b-893b-b86bd208a612" AggregationType="1" AggregationLower="3" AggregationUpper="3" />
 		</DocAttribute>
-		<DocAttribute Name="Closed" UniqueId="738880b2-be27-415d-acee-5b666ad13681" DefinedType="IfcBoolean" AttributeFlags="1">
-			<Documentation>Indication whether the _IfcTriangulatedFaceSet_ is a closed shell or not. If omited no such information can be provided.</Documentation>
-		</DocAttribute>
 		<DocAttribute Name="CoordIndex" UniqueId="9a0699f0-dcdd-4fa1-8373-7b1a46293902" DefinedType="IfcPositiveInteger" AggregationType="1" AggregationLower="1" AggregationUpper="0" XsdFormat="content" XsdTagless="true">
 			<Documentation>Two-dimensional list for the indexed-based triangles, where 
 * The first dimension represents the triangles (from 1 to N)


### PR DESCRIPTION
1. Removing IfcPolygonalFaceSet.Closed
2. Removing IfcTriangulatedFaceSet.Closed
3. Adding IfcTessellatedFaceSet.Closed

I would like to add that this change is part of the issue:
-	Faces : LIST [1:?] OF IfcIndexedPolygonalFace;
+	Faces : SET [1:?] OF IfcIndexedPolygonalFace;

but it is not in the official documentation, so I am unsure on what to do with it.