### PR TITLE
jwg12 ifc4 IfcBuildingSystemTypeEnum

### DIFF
--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/Types/IfcBuildingSystemTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/Types/IfcBuildingSystemTypeEnum/DocEnumeration.xml
@@ -11,9 +11,6 @@
 		<DocConstant xsi:nil="true" href="OUTERSHELL_2xcH0qqWHEIgpu3IiOB75J" />
 		<DocConstant xsi:nil="true" href="SHADING_0zbLM_unPFKB134UkR2_A" />
 		<DocConstant xsi:nil="true" href="TRANSPORT_1wmLCze7D5me077DpOmG49" />
-		<DocConstant xsi:nil="true" href="REINFORCING_1wLUHPCun99g9DErwRp4jx" />
-		<DocConstant xsi:nil="true" href="PRESTRESSING_0WjCg2NvDlRkFEjxezo0a" />
-		<DocConstant xsi:nil="true" href="EROSIONPREVENTION_0rmXHJF98Hx7U_MjSAKrf" />
 		<DocConstant xsi:nil="true" href="USERDEFINED_2enCWBVxDBnA4HoJ7Ez0Pk" />
 		<DocConstant xsi:nil="true" href="NOTDEFINED_0ecsZ6ab6DQv54zS_DVX" />
 	</Constants>


### PR DESCRIPTION
1. removed the constants that were added from IFC4 to IFC4X3 in IfcBuildingSystemTypeEnum

https://github.com/AECgeeks/infra-repo-issue-test-1/issues/4

The removed constants are now covered in IfcBuiltSystemTypeEnum due to the deprecation of IfcBuildingSystemTypeEnum.