### PR TITLE
IfcTendonConduit PDT modified to optional

### DIFF
--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcTendonConduit" Name="IfcTendonConduit" UniqueId="57495419-3d18-4767-a1be-2d689959ed20" BaseDefinition="IfcReinforcingElement" EntityFlags="32">
 	<Attributes>
-		<DocAttribute Name="PredefinedType" UniqueId="f8050fe4-62e7-45c6-8df5-8d142754034d" DefinedType="IfcTendonConduitTypeEnum">
+		<DocAttribute Name="PredefinedType" UniqueId="f8050fe4-62e7-45c6-8df5-8d142754034d" DefinedType="IfcTendonConduitTypeEnum" AttributeFlags="1">
 			<Documentation>The predefined generic type of the tendon conduit.</Documentation>
 		</DocAttribute>
 	</Attributes>
@@ -19,4 +19,3 @@
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
-


### PR DESCRIPTION
Fixes https://github.com/buildingSMART/IFC4.3.x-development/issues/576

1. `IfcTendonConduit.PredefinedType` set to `OPTIONAL`