### PR TITLE
`IfcVoxelData` Value type and WRs

### DIFF
--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/DocSchema.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/DocSchema.xml
@@ -86,7 +86,7 @@
 				<DocDefinitionRef Name="IfcNonNegativeLengthMeasure" UniqueId="125db395-a517-469c-8318-207858feeeef" />
 				<DocDefinitionRef Name="IfcPlaneAngleMeasure" UniqueId="110cd174-1607-44c7-8d9a-dab06de7d729" />
 				<DocDefinitionRef Name="IfcCurvatureMeasure" UniqueId="e0638995-1c5e-49df-adeb-6b66040390b5" />
-				<DocDefinitionRef Name="IfcInteger" UniqueId="fae0046d-fbec-4d27-9bbe-8d3499a507a6" />
+				<DocDefinitionRef id="IfcInteger_3wu0Hj__nD9vk_ZJIPfGUc" Name="IfcInteger" UniqueId="fae0046d-fbec-4d27-9bbe-8d3499a507a6" />
 				<DocDefinitionRef Name="IfcReal" UniqueId="a925c825-d2e0-48dd-95fa-0d8fa08ea4c2" />
 				<DocDefinitionRef Name="IfcLogical" UniqueId="11118895-43ea-439c-a85f-a64fee64c415" />
 			</Definitions>

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -14,21 +14,5 @@
 			</Definition>
 		</DocAttribute>
 	</Attributes>
-	<WhereRules>
-		<DocWhereRule Name="HasRepresentation" UniqueId="16865dc1-1980-43fd-8290-4bac0e77c2ca">
-			<Documentation>_IfcIntegerVoxelData_._Representation_ shall exist.</Documentation>
-			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
-		</DocWhereRule>
-		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="bb6f7739-0fb3-4899-a086-823cc53156f2">
-			<Documentation>The geometric representation item in _IfcProductDefinitionShape_._Representations_ shall be _IfcVoxelGrid_.</Documentation>
-			<Expression>&apos;IFCVOXELGRID&apos; IN TYPEOF(SELF\IfcProduct.Representation.Representations[1].Items[1])</Expression>
-		</DocWhereRule>
-		<DocWhereRule Name="SameGeometricRepresentation" UniqueId="9f6abff4-3bdb-4be7-8106-237e3b2e0e47">
-			<Documentation>RelatingProduct shall have the same geometric representation.</Documentation>
-			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation)
-AND
-SELF\IfcProduct.Representation.Representations[1].Items[1] = SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation.Representations[1].Items[1]</Expression>
-		</DocWhereRule>
-	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcIntegerVoxelData" UniqueId="f3d953cb-24b7-483d-85e1-d44c43d4d22b" BaseDefinition="IfcVoxelData" EntityFlags="32">
 	<Attributes>
-		<DocAttribute Name="Values" UniqueId="342aa966-eaa4-4d0c-87e5-91988a4f1c0a" DefinedType="IfcInteger" AggregationType="2" AggregationLower="1">
+		<DocAttribute Name="Values" UniqueId="342aa966-eaa4-4d0c-87e5-91988a4f1c0a" DefinedType="IfcInteger" AggregationType="2" AggregationLower="1" AggregationUpper="GridSize">
 			<Documentation>The values assigned to the voxels. First x, then y and lastly z.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="Unit" UniqueId="d23d69e2-c35a-41d5-bf3b-9533670b9eb7" DefinedType="IfcUnit" AttributeFlags="1">

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -25,9 +25,9 @@
 		</DocWhereRule>
 		<DocWhereRule Name="SameGeometricRepresentation" UniqueId="9f6abff4-3bdb-4be7-8106-237e3b2e0e47">
 			<Documentation>RelatingProduct shall have the same geometric representation.</Documentation>
-			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignment\IfcRelAssignsToProduct.RelatingProduct.Representation)
+			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation)
 AND
-SELF\IfcProduct.Representation.Representations[1].Items[1] = SELF\IfcObjectDefinition.HasAssignment\IfcRelAssignsToProduct.RelatingProduct.Representation.Representations[1].Items[1]</Expression>
+SELF\IfcProduct.Representation.Representations[1].Items[1] = SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation.Representations[1].Items[1]</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -7,6 +7,12 @@
 		<DocAttribute Name="Unit" UniqueId="d23d69e2-c35a-41d5-bf3b-9533670b9eb7" DefinedType="IfcUnit" AttributeFlags="1">
 			<Documentation>An optional unit for the integer values.</Documentation>
 		</DocAttribute>
+		<DocAttribute Name="GridSize" UniqueId="6f8d6a89-e211-4ca1-a678-e4221b561f42" DefinedType="IfcInteger">
+			<Derived> SIZEOF(SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</Derived>
+			<Definition>
+				<DocDefinitionRef xsi:nil="true" href="IfcInteger_3wu0Hj__nD9vk_ZJIPfGUc" />
+			</Definition>
+		</DocAttribute>
 	</Attributes>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -19,6 +19,10 @@
 			<Documentation>_IfcIntegerVoxelData_. _Representation_ shall exist.</Documentation>
 			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
 		</DocWhereRule>
+		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="bb6f7739-0fb3-4899-a086-823cc53156f2">
+			<Documentation>The geometric representation item in _IfcProductDefinitionShape_._Representations_ shall be _IfcVoxelGrid_.</Documentation>
+			<Expression>&apos;IFCVOXELGRID&apos; IN TYPEOF(SELF\IfcProduct.Representation.Representations[1].Items[1])</Expression>
+		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -16,7 +16,7 @@
 	</Attributes>
 	<WhereRules>
 		<DocWhereRule Name="HasRepresentation" UniqueId="16865dc1-1980-43fd-8290-4bac0e77c2ca">
-			<Documentation>_IfcIntegerVoxelData_. _Representation_ shall exist.</Documentation>
+			<Documentation>_IfcIntegerVoxelData_._Representation_ shall exist.</Documentation>
 			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
 		</DocWhereRule>
 		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="bb6f7739-0fb3-4899-a086-823cc53156f2">

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -14,5 +14,11 @@
 			</Definition>
 		</DocAttribute>
 	</Attributes>
+	<WhereRules>
+		<DocWhereRule Name="HasRepresentation" UniqueId="16865dc1-1980-43fd-8290-4bac0e77c2ca">
+			<Documentation>_IfcIntegerVoxelData_. _Representation_ shall exist.</Documentation>
+			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
+		</DocWhereRule>
+	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcIntegerVoxelData/DocEntity.xml
@@ -23,6 +23,12 @@
 			<Documentation>The geometric representation item in _IfcProductDefinitionShape_._Representations_ shall be _IfcVoxelGrid_.</Documentation>
 			<Expression>&apos;IFCVOXELGRID&apos; IN TYPEOF(SELF\IfcProduct.Representation.Representations[1].Items[1])</Expression>
 		</DocWhereRule>
+		<DocWhereRule Name="SameGeometricRepresentation" UniqueId="9f6abff4-3bdb-4be7-8106-237e3b2e0e47">
+			<Documentation>RelatingProduct shall have the same geometric representation.</Documentation>
+			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignment\IfcRelAssignsToProduct.RelatingProduct.Representation)
+AND
+SELF\IfcProduct.Representation.Representations[1].Items[1] = SELF\IfcObjectDefinition.HasAssignment\IfcRelAssignsToProduct.RelatingProduct.Representation.Representations[1].Items[1]</Expression>
+		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
@@ -5,5 +5,30 @@
 			<Documentation>An optional value type used for the values defined in one of the subtypes. Only the names (as labels) of the types available in the _IfcValue_ select type are allowed.</Documentation>
 		</DocAttribute>
 	</Attributes>
+	<WhereRules>
+		<DocWhereRule Name="IsAssignedToProduct" UniqueId="1a35cca4-513b-4358-be9c-abe93df51a6b">
+			<Documentation>_IfcVoxelData_ shall have exactly one assignment to a product of type _IfcRelAssignsToProduct_.</Documentation>
+			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignments)
+AND
+SIZEOF(SELF\IfcObjectDefinition.HasAssignments) = 1
+AND
+&apos;IFCRELASSIGNSTOPRODUCT&apos; IN TYPEOF(SELF\IfcObjectDefinition.HasAssignments[1])</Expression>
+		</DocWhereRule>
+		<DocWhereRule Name="HasRepresentation" UniqueId="3caf1533-687f-4af7-9621-967ad14407a6">
+			<Documentation>_IfcIntegerVoxelData_._Representation_ shall exist.</Documentation>
+			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
+		</DocWhereRule>
+		<DocWhereRule Name="SameRepresentation" UniqueId="02d00e6c-4372-463f-aef6-49b483f51e21">
+			<Documentation>RelatingProduct shall have the same product representation.</Documentation>
+			<Expression>SELF\IfcProduct.Representation = SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation</Expression>
+		</DocWhereRule>
+		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="75daf693-a914-48d9-9f98-0675cad82c89">
+			<Documentation>There shall be exactly one _IfcShapeRepresentation_ in _IfcProductDefinitionShape_._Representations_ that has exactly one geometric item _IfcVoxelGrid_.</Documentation>
+			<Expression>SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcProduct.Representation.Representations | 
+SIZEOF(ShapeRep.Items) = 1
+AND
+&apos;IFCVOXELGRID&apos; IN TYPEOF(ShapeRep.Items[1])) = 1</Expression>
+		</DocWhereRule>
+	</WhereRules>
 </DocEntity>
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
@@ -6,3 +6,4 @@
 		</DocAttribute>
 	</Attributes>
 </DocEntity>
+

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
@@ -7,27 +7,26 @@
 	</Attributes>
 	<WhereRules>
 		<DocWhereRule Name="IsAssignedToProduct" UniqueId="1a35cca4-513b-4358-be9c-abe93df51a6b">
-			<Documentation>_IfcVoxelData_ shall have exactly one assignment to a product of type _IfcRelAssignsToProduct_.</Documentation>
+			<Documentation>_IfcVoxelData_ shall have exactly one assignment relationship of type _IfcRelAssignsToProduct_ to a product.</Documentation>
 			<Expression>EXISTS(SELF\IfcObjectDefinition.HasAssignments)
 AND
 SIZEOF(SELF\IfcObjectDefinition.HasAssignments) = 1
 AND
 &apos;IFCRELASSIGNSTOPRODUCT&apos; IN TYPEOF(SELF\IfcObjectDefinition.HasAssignments[1])</Expression>
 		</DocWhereRule>
-		<DocWhereRule Name="HasRepresentation" UniqueId="3caf1533-687f-4af7-9621-967ad14407a6">
-			<Documentation>_IfcIntegerVoxelData_._Representation_ shall exist.</Documentation>
-			<Expression>EXISTS(SELF\IfcProduct.Representation)</Expression>
+		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="75daf693-a914-48d9-9f98-0675cad82c89">
+			<Documentation>_IfcVoxelData_ shall have a product definition shape and there shall be exactly one _IfcShapeRepresentation_ in _IfcProductDefinitionShape_._Representations_ that has exactly one geometric item _IfcVoxelGrid_.</Documentation>
+			<Expression>EXISTS(SELF\IfcProduct.Representation)
+AND
+SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcProduct.Representation.Representations | 
+    SIZEOF(ShapeRep.Items) = 1
+    AND
+    &apos;IFCVOXELGRID&apos; IN TYPEOF(ShapeRep.Items[1]))) = 1</Expression>
 		</DocWhereRule>
 		<DocWhereRule Name="SameRepresentation" UniqueId="02d00e6c-4372-463f-aef6-49b483f51e21">
-			<Documentation>RelatingProduct shall have the same product representation.</Documentation>
-			<Expression>SELF\IfcProduct.Representation = SELF\IfcObjectDefinition.HasAssignments\IfcRelAssignsToProduct.RelatingProduct.Representation</Expression>
-		</DocWhereRule>
-		<DocWhereRule Name="VoxelGridRepresentation" UniqueId="75daf693-a914-48d9-9f98-0675cad82c89">
-			<Documentation>There shall be exactly one _IfcShapeRepresentation_ in _IfcProductDefinitionShape_._Representations_ that has exactly one geometric item _IfcVoxelGrid_.</Documentation>
-			<Expression>SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcProduct.Representation.Representations | 
-SIZEOF(ShapeRep.Items) = 1
-AND
-&apos;IFCVOXELGRID&apos; IN TYPEOF(ShapeRep.Items[1])) = 1</Expression>
+			<Documentation>The assigned _IfcProduct_ shall have the same shape representation.</Documentation>
+			<Expression>SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcObjectDefinition.HasAssignments[1]\IfcRelAssignsToProduct.RelatingProduct\IfcProduct.Representation.Representations) |
+ShapeRep = SELF\IfcProduct.Representation.Representations[1]) = 1</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
@@ -19,3 +19,4 @@
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
+

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcCompositeCurveSegment/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcCompositeCurveSegment/DocEntity.xml
@@ -24,3 +24,4 @@
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
+


### PR DESCRIPTION
Fixes #492 

1. [eof lines added](https://github.com/bSI-InfraRoom/IFC-Specification/commit/ce087396bc5a3949e2b90f823dc9464048ad2794)
2. [adding derived GridSize](https://github.com/bSI-InfraRoom/IFC-Specification/commit/26f44afdae8354079eca7620c67ad10e301f4ad5)
3. [upper bound of Values attribute](https://github.com/bSI-InfraRoom/IFC-Specification/commit/4ac73b71b9bf1914e3bf2dfc24b2fc910831522b)
4. [adding HasRepresentation WR](https://github.com/bSI-InfraRoom/IFC-Specification/commit/5ab993743d0e42110bbfdc757af7ce223a5dcd3e)
5. [adding VoxelGridRepresentation WR](https://github.com/bSI-InfraRoom/IFC-Specification/commit/e3ebd444ba8f07d25d2989bc3a573674999796d5)
6. [adding SameGeometricRepresentation WR](https://github.com/bSI-InfraRoom/IFC-Specification/commit/35c0e02285498d10073ea98efa97a6c5678e083e)

I realized that the WRs should be on `IfcVoxelData` probably. Not that important and quickly fixed so please ignore this.

EDIT: Forgot to add before. The issue with GridSize is that it is not known at object construction time. Any suggestions how to handle this?