### PR TITLE
Changed the wording of General Usage for Project Template Definitions

### DIFF
--- a/IFC4x3/ModelViews/General Usage/DocModelView.xml
+++ b/IFC4x3/ModelViews/General Usage/DocModelView.xml
@@ -10395,7 +10395,7 @@ The following constraints apply to the 2D representation:
 					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Project_Type_Definitions_1ZJYVtVjjE8hZC9V7DnsNE" />
 				</DocTemplateUsage>
 				<DocTemplateUsage Name="Property Template Definitions" UniqueId="5fefb1c9-1031-4001-b664-9f4b44f78607">
-					<Documentation>If a project includes custom properties for which end users should be able to view and/or edit, then backing property templates must be defined. Such templates define applicable data types and values. Applications should not allow modification of any custom properties (other than those defined within this specification) for which no template is available.</Documentation>
+					<Documentation>If a project includes custom properties which end users should be able to edit, then backing property templates must be defined. Such templates define applicable data types and values. Applications should not allow modification of any custom properties (other than those defined within this specification) for which no template is available.</Documentation>
 					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Project_Template_Definitions_3MxTphmG92Hux09EVKnTgR" />
 				</DocTemplateUsage>
 				<DocTemplateUsage Name="Project Units" UniqueId="3Vl6VKGiXCZBtA8ht6A7Sg">


### PR DESCRIPTION
I am unsure about this change. But I believe it is more clear now, what is the requirement.

I would love to hear your opinions.

Fixes #546 .