### PR TITLE
linear breakdown

### DIFF
--- a/IFC4x3/ModelViews/General Usage/DocModelView.xml
+++ b/IFC4x3/ModelViews/General Usage/DocModelView.xml
@@ -189,6 +189,82 @@ The **IfcActionRequest** may have assignments of its own using the [IfcRelAssign
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="8767157b-e1b7-469b-baeb-1ada744fc073" Type="IfcActuator" />
 		</DocConceptRoot>
+		<DocConceptRoot UniqueId="1Pxzk8yZ9F3Pr62EWQpZun">
+			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAirTerminalBox" />
+			<Concepts>
+				<DocTemplateUsage Name="Object Typing" UniqueId="0TBp0NoOD53espxF88riQX">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Object_Typing_0rek4E8Dz0zAilsiyAPqJq" />
+					<Items>
+						<DocTemplateItem UniqueId="3bff3bf2-2413-495e-8473-904961be492d" RuleParameters="RelatingType=IfcAirTerminalBoxType;" />
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage UniqueId="2hKjUj6srBquVqp5aaqI4X">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Property_Sets_for_Objects_3tGbMc30vFCOIj99WTjYHX" />
+					<Items>
+						<DocTemplateItem UniqueId="15d5d2fe-667b-4db9-8b4f-247f7ac97193" RuleParameters="PsetName=Pset_AirTerminalBoxTypeCommon;">
+							<Concepts>
+								<DocTemplateUsage Name="Properties" UniqueId="e28a0424-99eb-4206-ad7f-30314aaef369">
+									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Single_Value_1cLVRGAQX7k8yzoVpfoQOW" />
+									<Items>
+										<DocTemplateItem UniqueId="ee664fdc-4cd3-43db-90cf-7b2ab190840f" RuleParameters="PropertyName=Reference;Value=IfcIdentifier;" />
+										<DocTemplateItem UniqueId="268bd7be-5f52-4c91-b5e3-e6a974f1e572" RuleParameters="PropertyName=NominalAirFlowRate;Value=IfcVolumetricFlowRateMeasure;" />
+										<DocTemplateItem UniqueId="69f692f4-b9d0-4478-a210-c1b23a668ef3" RuleParameters="PropertyName=HasSoundAttenuator;Value=IfcBoolean;" />
+										<DocTemplateItem UniqueId="721dac5b-931c-4a19-a541-7dc44be04142" RuleParameters="PropertyName=HasReturnAir;Value=IfcBoolean;" />
+										<DocTemplateItem UniqueId="26c93cd0-8e43-4396-979d-4db665b3c973" RuleParameters="PropertyName=HasFan;Value=IfcBoolean;" />
+										<DocTemplateItem UniqueId="f5f3c3e5-e967-415d-a829-9e77c676fa29" RuleParameters="PropertyName=NominalInletAirPressure;Value=IfcPressureMeasure;" />
+										<DocTemplateItem UniqueId="1329dc58-c6bb-4c36-b194-c4abc9de711d" RuleParameters="PropertyName=NominalDamperDiameter;Value=IfcPositiveLengthMeasure;" />
+										<DocTemplateItem UniqueId="ff7d253f-0ab7-4fd6-99f3-27e2e5cd2c37" RuleParameters="PropertyName=HousingThickness;Value=IfcLengthMeasure;" />
+									</Items>
+								</DocTemplateUsage>
+								<DocTemplateUsage Name="Properties" UniqueId="7def8c42-4bc5-4066-922b-aa525d161642">
+									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Enumerated_Value_31IA2Pmr53g99cNptWj5gL" />
+									<Items>
+										<DocTemplateItem UniqueId="74cd685e-efa9-408d-a36c-bb9738152abd" RuleParameters="PropertyName=Status;Value=IfcLabel;" />
+										<DocTemplateItem UniqueId="0f9c9f7f-8681-4220-a2a2-dfe46a85ad8f" RuleParameters="PropertyName=ArrangementType;Value=IfcLabel;" />
+										<DocTemplateItem UniqueId="d14ca116-15d0-4263-9810-a92cfe63b648" RuleParameters="PropertyName=ReheatType;Value=IfcLabel;" />
+									</Items>
+								</DocTemplateUsage>
+								<DocTemplateUsage Name="Properties" UniqueId="fb36be03-0691-41fd-b400-99471bf19972">
+									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Bounded_Value_0zPwBITXr4sQ2Ujkn_bOo" />
+									<Items>
+										<DocTemplateItem UniqueId="df4f0d0b-adad-4c4b-ae05-ddf48caad11c" RuleParameters="PropertyName=AirflowRateRange;SetValue=IfcVolumetricFlowRateMeasure;" />
+										<DocTemplateItem UniqueId="072540f0-d54c-4dad-a43e-0927e7844df1" RuleParameters="PropertyName=AirPressureRange;SetValue=IfcPressureMeasure;" />
+										<DocTemplateItem UniqueId="6a0f0eef-7ee8-4153-b72d-2111fad7cd64" RuleParameters="PropertyName=OperationTemperatureRange;SetValue=IfcThermodynamicTemperatureMeasure;" />
+										<DocTemplateItem UniqueId="7bec6bb4-995b-4a02-ad4e-33ebdfbc6955" RuleParameters="PropertyName=ReturnAirFractionRange;SetValue=IfcPositiveRatioMeasure;" />
+									</Items>
+								</DocTemplateUsage>
+							</Concepts>
+						</DocTemplateItem>
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage UniqueId="2q8xRrdBH7Xeid0qRrzsa5">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Quantity_Sets_1cKZcEPNb4O8oq9YbQpwp7" />
+					<Items>
+						<DocTemplateItem UniqueId="78d488e5-a321-4d60-bc95-ec86f9089d70" RuleInstanceID="IfcElementQuantity" RuleParameters="QsetName=Qto_AirTerminalBoxTypeBaseQuantities;" />
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Material" UniqueId="0NRMsKLmz52Bty688VpRVe">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Material_Constituent_Set_3PRtzzvq9Dk9jT6ADgRVY4" />
+					<Items>
+						<DocTemplateItem UniqueId="a38ab416-59b1-4736-9a91-51feb598e095" RuleParameters="Name=Casing;">
+							<Documentation>Material from which the casing is constructed.</Documentation>
+						</DocTemplateItem>
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Port" UniqueId="1I6dosBojB5xl0xpMM09lZ">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Port_Nesting_2w9EtqE92s8JFNQ8EuKWA" />
+					<Items>
+						<DocTemplateItem UniqueId="929bacad-80ba-465a-9086-b91418ba5d0c" RuleParameters="PortName=Inlet;SystemType=AIRCONDITIONING;Flow=SINK;">
+							<Documentation>Incoming air.</Documentation>
+						</DocTemplateItem>
+						<DocTemplateItem UniqueId="381c4d37-02b3-4960-ba6e-acaf7aa3d72a" RuleParameters="PortName=Outlet;SystemType=AIRCONDITIONING;Flow=SOURCE;">
+							<Documentation>Outgoing regulated air.</Documentation>
+						</DocTemplateItem>
+					</Items>
+				</DocTemplateUsage>
+			</Concepts>
+			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="e2e04114-23d9-473e-b293-f826c2e9426f" Type="IfcAirTerminalBox" />
+		</DocConceptRoot>
 		<DocConceptRoot UniqueId="3o93NQJ3zEpBDHEmGrApxV">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAirTerminal" />
 			<Concepts>
@@ -294,82 +370,6 @@ The **IfcActionRequest** may have assignments of its own using the [IfcRelAssign
 				</DocTemplateUsage>
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="6c2cdceb-d003-4934-8389-d4ccf68ed1e3" Type="IfcAirTerminal" />
-		</DocConceptRoot>
-		<DocConceptRoot UniqueId="1Pxzk8yZ9F3Pr62EWQpZun">
-			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAirTerminalBox" />
-			<Concepts>
-				<DocTemplateUsage Name="Object Typing" UniqueId="0TBp0NoOD53espxF88riQX">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Object_Typing_0rek4E8Dz0zAilsiyAPqJq" />
-					<Items>
-						<DocTemplateItem UniqueId="3bff3bf2-2413-495e-8473-904961be492d" RuleParameters="RelatingType=IfcAirTerminalBoxType;" />
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage UniqueId="2hKjUj6srBquVqp5aaqI4X">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Property_Sets_for_Objects_3tGbMc30vFCOIj99WTjYHX" />
-					<Items>
-						<DocTemplateItem UniqueId="15d5d2fe-667b-4db9-8b4f-247f7ac97193" RuleParameters="PsetName=Pset_AirTerminalBoxTypeCommon;">
-							<Concepts>
-								<DocTemplateUsage Name="Properties" UniqueId="e28a0424-99eb-4206-ad7f-30314aaef369">
-									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Single_Value_1cLVRGAQX7k8yzoVpfoQOW" />
-									<Items>
-										<DocTemplateItem UniqueId="ee664fdc-4cd3-43db-90cf-7b2ab190840f" RuleParameters="PropertyName=Reference;Value=IfcIdentifier;" />
-										<DocTemplateItem UniqueId="268bd7be-5f52-4c91-b5e3-e6a974f1e572" RuleParameters="PropertyName=NominalAirFlowRate;Value=IfcVolumetricFlowRateMeasure;" />
-										<DocTemplateItem UniqueId="69f692f4-b9d0-4478-a210-c1b23a668ef3" RuleParameters="PropertyName=HasSoundAttenuator;Value=IfcBoolean;" />
-										<DocTemplateItem UniqueId="721dac5b-931c-4a19-a541-7dc44be04142" RuleParameters="PropertyName=HasReturnAir;Value=IfcBoolean;" />
-										<DocTemplateItem UniqueId="26c93cd0-8e43-4396-979d-4db665b3c973" RuleParameters="PropertyName=HasFan;Value=IfcBoolean;" />
-										<DocTemplateItem UniqueId="f5f3c3e5-e967-415d-a829-9e77c676fa29" RuleParameters="PropertyName=NominalInletAirPressure;Value=IfcPressureMeasure;" />
-										<DocTemplateItem UniqueId="1329dc58-c6bb-4c36-b194-c4abc9de711d" RuleParameters="PropertyName=NominalDamperDiameter;Value=IfcPositiveLengthMeasure;" />
-										<DocTemplateItem UniqueId="ff7d253f-0ab7-4fd6-99f3-27e2e5cd2c37" RuleParameters="PropertyName=HousingThickness;Value=IfcLengthMeasure;" />
-									</Items>
-								</DocTemplateUsage>
-								<DocTemplateUsage Name="Properties" UniqueId="7def8c42-4bc5-4066-922b-aa525d161642">
-									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Enumerated_Value_31IA2Pmr53g99cNptWj5gL" />
-									<Items>
-										<DocTemplateItem UniqueId="74cd685e-efa9-408d-a36c-bb9738152abd" RuleParameters="PropertyName=Status;Value=IfcLabel;" />
-										<DocTemplateItem UniqueId="0f9c9f7f-8681-4220-a2a2-dfe46a85ad8f" RuleParameters="PropertyName=ArrangementType;Value=IfcLabel;" />
-										<DocTemplateItem UniqueId="d14ca116-15d0-4263-9810-a92cfe63b648" RuleParameters="PropertyName=ReheatType;Value=IfcLabel;" />
-									</Items>
-								</DocTemplateUsage>
-								<DocTemplateUsage Name="Properties" UniqueId="fb36be03-0691-41fd-b400-99471bf19972">
-									<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Bounded_Value_0zPwBITXr4sQ2Ujkn_bOo" />
-									<Items>
-										<DocTemplateItem UniqueId="df4f0d0b-adad-4c4b-ae05-ddf48caad11c" RuleParameters="PropertyName=AirflowRateRange;SetValue=IfcVolumetricFlowRateMeasure;" />
-										<DocTemplateItem UniqueId="072540f0-d54c-4dad-a43e-0927e7844df1" RuleParameters="PropertyName=AirPressureRange;SetValue=IfcPressureMeasure;" />
-										<DocTemplateItem UniqueId="6a0f0eef-7ee8-4153-b72d-2111fad7cd64" RuleParameters="PropertyName=OperationTemperatureRange;SetValue=IfcThermodynamicTemperatureMeasure;" />
-										<DocTemplateItem UniqueId="7bec6bb4-995b-4a02-ad4e-33ebdfbc6955" RuleParameters="PropertyName=ReturnAirFractionRange;SetValue=IfcPositiveRatioMeasure;" />
-									</Items>
-								</DocTemplateUsage>
-							</Concepts>
-						</DocTemplateItem>
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage UniqueId="2q8xRrdBH7Xeid0qRrzsa5">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Quantity_Sets_1cKZcEPNb4O8oq9YbQpwp7" />
-					<Items>
-						<DocTemplateItem UniqueId="78d488e5-a321-4d60-bc95-ec86f9089d70" RuleInstanceID="IfcElementQuantity" RuleParameters="QsetName=Qto_AirTerminalBoxTypeBaseQuantities;" />
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Material" UniqueId="0NRMsKLmz52Bty688VpRVe">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Material_Constituent_Set_3PRtzzvq9Dk9jT6ADgRVY4" />
-					<Items>
-						<DocTemplateItem UniqueId="a38ab416-59b1-4736-9a91-51feb598e095" RuleParameters="Name=Casing;">
-							<Documentation>Material from which the casing is constructed.</Documentation>
-						</DocTemplateItem>
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Port" UniqueId="1I6dosBojB5xl0xpMM09lZ">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Port_Nesting_2w9EtqE92s8JFNQ8EuKWA" />
-					<Items>
-						<DocTemplateItem UniqueId="929bacad-80ba-465a-9086-b91418ba5d0c" RuleParameters="PortName=Inlet;SystemType=AIRCONDITIONING;Flow=SINK;">
-							<Documentation>Incoming air.</Documentation>
-						</DocTemplateItem>
-						<DocTemplateItem UniqueId="381c4d37-02b3-4960-ba6e-acaf7aa3d72a" RuleParameters="PortName=Outlet;SystemType=AIRCONDITIONING;Flow=SOURCE;">
-							<Documentation>Outgoing regulated air.</Documentation>
-						</DocTemplateItem>
-					</Items>
-				</DocTemplateUsage>
-			</Concepts>
-			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="e2e04114-23d9-473e-b293-f826c2e9426f" Type="IfcAirTerminalBox" />
 		</DocConceptRoot>
 		<DocConceptRoot UniqueId="15H$pjiyn1kAvbXzBNZzqu">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcAirToAirHeatRecovery" />
@@ -9084,6 +9084,16 @@ The shared profile definition is defined by assigning an _IfcMaterialProfileSet_
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="10dc7aff-b009-4e0a-819c-f29c9ea7a86d" Type="IfcMotorConnection" />
 		</DocConceptRoot>
+		<DocConceptRoot UniqueId="f26454ea-55a9-4d8f-a2a0-ab8a5561112d">
+			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcObjectDefinition" />
+			<Concepts>
+				<DocTemplateUsage Name="Classification Association" UniqueId="dcfad64e-cedb-4766-b609-cfe82ae3ae44">
+					<Documentation>Any object occurrence or object type can have a reference to a specific classification reference, i.e. to a particular facet within a classification system.</Documentation>
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Classification_Association_1A8aO9PNXCTQFYl_eRbxo" />
+				</DocTemplateUsage>
+			</Concepts>
+			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="95f14c0b-d81c-49cb-be71-edd4e4eb395c" Type="IfcObjectDefinition" />
+		</DocConceptRoot>
 		<DocConceptRoot UniqueId="e60ba889-b830-457c-8551-1f5bb04e7377">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcObject" />
 			<Concepts>
@@ -9108,16 +9118,6 @@ The shared profile definition is defined by assigning an _IfcMaterialProfileSet_
 				</DocTemplateUsage>
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="c7ad266e-1918-4f78-b6a7-7c889a92e44f" Type="IfcObject" />
-		</DocConceptRoot>
-		<DocConceptRoot UniqueId="f26454ea-55a9-4d8f-a2a0-ab8a5561112d">
-			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcObjectDefinition" />
-			<Concepts>
-				<DocTemplateUsage Name="Classification Association" UniqueId="dcfad64e-cedb-4766-b609-cfe82ae3ae44">
-					<Documentation>Any object occurrence or object type can have a reference to a specific classification reference, i.e. to a particular facet within a classification system.</Documentation>
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Classification_Association_1A8aO9PNXCTQFYl_eRbxo" />
-				</DocTemplateUsage>
-			</Concepts>
-			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="95f14c0b-d81c-49cb-be71-edd4e4eb395c" Type="IfcObjectDefinition" />
 		</DocConceptRoot>
 		<DocConceptRoot UniqueId="06zJhGZ3b2Z9WyU$Kglfdd">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcOccupant" />
@@ -10340,6 +10340,12 @@ The following constraints apply to the 2D representation:
 						<DocTemplateItem UniqueId="4dd8c791-f2b2-454c-b375-0a076169b863" />
 					</Items>
 				</DocTemplateUsage>
+				<DocTemplateUsage Name="Product Relative Placement" UniqueId="da293ffd-2422-4d95-a727-af95bf396859">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Product_Relative_Placement_3qqFBayh18_9VwpdiT9QZ9" />
+					<Items>
+						<DocTemplateItem UniqueId="638e8614-2c61-437d-8ac7-547257226dc9" />
+					</Items>
+				</DocTemplateUsage>
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="c05ec892-7ee3-4be3-a779-d9e51cbaa80d" Type="IfcProduct" />
 		</DocConceptRoot>
@@ -11548,6 +11554,17 @@ Figure 1 illustrates the body representation.
 				</DocTemplateUsage>
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="37aafe93-2040-4894-ade6-ae23600af30e" Type="IfcRampType" />
+		</DocConceptRoot>
+		<DocConceptRoot Name="IfcReferent" UniqueId="488f44bb-7226-4fb2-a7df-1add5f9f2176">
+			<Concepts>
+				<DocTemplateUsage Name="Station" UniqueId="2e5fc2b5-fab9-4c4f-a6cc-e07787086463">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Station_0a_CIglHH8wBXulkH9IhxC" />
+					<Items>
+						<DocTemplateItem UniqueId="3810aa4c-139f-46de-92bd-c8448daa9e1c" />
+					</Items>
+				</DocTemplateUsage>
+			</Concepts>
+			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="5de9188f-66ab-4c7d-a147-a26a2682fdb8" />
 		</DocConceptRoot>
 		<DocConceptRoot UniqueId="1q28YTOErF6fSdS$eXi7nI">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcReinforcingBar" />
@@ -14204,6 +14221,37 @@ A top-level task is declared within the _IfcProject_ using the _IfcRelDeclares_ 
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="afcd0ee6-4a97-414e-b59c-a945f6775860" Type="IfcTaskType" />
 		</DocConceptRoot>
+		<DocConceptRoot UniqueId="1HHBUDWXDA$9J6RdO8r3dF">
+			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcTendonAnchor" />
+			<Concepts>
+				<DocTemplateUsage Name="Object Typing" UniqueId="0tWD1X6NjFdRZQaFfuhxxr">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Object_Typing_0rek4E8Dz0zAilsiyAPqJq" />
+					<Items>
+						<DocTemplateItem UniqueId="d1ce5fe9-4d55-4122-a53b-a31a6120ffd6" RuleParameters="RelatingType=IfcTendonAnchorType;" />
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Property Sets" UniqueId="1oO5voX7bEbBdU5tANHjvM">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Property_Sets_for_Objects_3tGbMc30vFCOIj99WTjYHX" />
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Quantity Sets" UniqueId="0pIpRL3GX0fgz7Hd6ZLPTr">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Quantity_Sets_1cKZcEPNb4O8oq9YbQpwp7" />
+					<Items>
+						<DocTemplateItem UniqueId="67fb1e5f-a2be-4ec9-b036-e0f5dd9ec248" RuleParameters="QsetName=Qto_ReinforcingElementBaseQuantities;TemplateType=QTO_TYPEDRIVENOVERRIDE;" />
+					</Items>
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Placement" UniqueId="ce8cfd65-7c6e-46f3-9dd7-2bb242183c9c">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Product_Local_Placement_3Bw5jVUH9AGukt7cEGB9j" />
+				</DocTemplateUsage>
+				<DocTemplateUsage Name="Body Geometry" UniqueId="60ed48e7-ae53-4af1-bae1-77bd85b76a8b">
+					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Body_Geometry_34HhqMBUDBbxDFH4Qi2wt2" />
+					<Items>
+						<DocTemplateItem UniqueId="a08cdbad-b7fd-49d0-b3c7-9f0a9eb04737" RuleParameters="RepresentationType=SweptSolid;Geometry=IfcSweptDiskSolid;" />
+						<DocTemplateItem UniqueId="97f4bdab-a0c8-4c7e-9a91-87405bae11fe" RuleParameters="RepresentationType=MappedRepresentation;Geometry=IfcMappedItem;" />
+					</Items>
+				</DocTemplateUsage>
+			</Concepts>
+			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="40a4c90d-4d9b-406a-89cd-4db23740d7fd" Type="IfcTendonAnchor" />
+		</DocConceptRoot>
 		<DocConceptRoot UniqueId="2v_xF90910JP7FnwYYspMt">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcTendon" />
 			<Concepts>
@@ -14241,37 +14289,6 @@ A top-level task is declared within the _IfcProject_ using the _IfcRelDeclares_ 
 				</DocTemplateUsage>
 			</Concepts>
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="7eecb932-2b46-48ca-a42f-48c3aa508847" Type="IfcTendon" />
-		</DocConceptRoot>
-		<DocConceptRoot UniqueId="1HHBUDWXDA$9J6RdO8r3dF">
-			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcTendonAnchor" />
-			<Concepts>
-				<DocTemplateUsage Name="Object Typing" UniqueId="0tWD1X6NjFdRZQaFfuhxxr">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Object_Typing_0rek4E8Dz0zAilsiyAPqJq" />
-					<Items>
-						<DocTemplateItem UniqueId="d1ce5fe9-4d55-4122-a53b-a31a6120ffd6" RuleParameters="RelatingType=IfcTendonAnchorType;" />
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Property Sets" UniqueId="1oO5voX7bEbBdU5tANHjvM">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Property_Sets_for_Objects_3tGbMc30vFCOIj99WTjYHX" />
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Quantity Sets" UniqueId="0pIpRL3GX0fgz7Hd6ZLPTr">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Quantity_Sets_1cKZcEPNb4O8oq9YbQpwp7" />
-					<Items>
-						<DocTemplateItem UniqueId="67fb1e5f-a2be-4ec9-b036-e0f5dd9ec248" RuleParameters="QsetName=Qto_ReinforcingElementBaseQuantities;TemplateType=QTO_TYPEDRIVENOVERRIDE;" />
-					</Items>
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Placement" UniqueId="ce8cfd65-7c6e-46f3-9dd7-2bb242183c9c">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Product_Local_Placement_3Bw5jVUH9AGukt7cEGB9j" />
-				</DocTemplateUsage>
-				<DocTemplateUsage Name="Body Geometry" UniqueId="60ed48e7-ae53-4af1-bae1-77bd85b76a8b">
-					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Body_Geometry_34HhqMBUDBbxDFH4Qi2wt2" />
-					<Items>
-						<DocTemplateItem UniqueId="a08cdbad-b7fd-49d0-b3c7-9f0a9eb04737" RuleParameters="RepresentationType=SweptSolid;Geometry=IfcSweptDiskSolid;" />
-						<DocTemplateItem UniqueId="97f4bdab-a0c8-4c7e-9a91-87405bae11fe" RuleParameters="RepresentationType=MappedRepresentation;Geometry=IfcMappedItem;" />
-					</Items>
-				</DocTemplateUsage>
-			</Concepts>
-			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="40a4c90d-4d9b-406a-89cd-4db23740d7fd" Type="IfcTendonAnchor" />
 		</DocConceptRoot>
 		<DocConceptRoot Name="IfcTendonType" UniqueId="fec63430-767c-4817-b3e3-132214bfb8ac">
 			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcTendonType" />

--- a/IFC4x3/ModelViews/General Usage/DocModelView.xml
+++ b/IFC4x3/ModelViews/General Usage/DocModelView.xml
@@ -11556,6 +11556,7 @@ Figure 1 illustrates the body representation.
 			<ApplicableTemplate xsi:type="DocTemplateDefinition" UniqueId="37aafe93-2040-4894-ade6-ae23600af30e" Type="IfcRampType" />
 		</DocConceptRoot>
 		<DocConceptRoot Name="IfcReferent" UniqueId="488f44bb-7226-4fb2-a7df-1add5f9f2176">
+			<ApplicableEntity xsi:type="DocEntity" xsi:nil="true" href="IfcReferent" />
 			<Concepts>
 				<DocTemplateUsage Name="Station" UniqueId="2e5fc2b5-fab9-4c4f-a6cc-e07787086463">
 					<Definition xsi:type="DocTemplateDefinition" xsi:nil="true" href="Station_0a_CIglHH8wBXulkH9IhxC" />

--- a/IFC4x3/Properties/m/MaterialColour_3yAyxI68v5rR3KlzC79inK/DocProperty.xml
+++ b/IFC4x3/Properties/m/MaterialColour_3yAyxI68v5rR3KlzC79inK/DocProperty.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="MaterialColour_3yAyxI68v5rR3KlzC79inK" Name="MaterialColour" UniqueId="fc2bced2-188e-45d5-b0d4-bfd30726cc54" PrimaryDataType="IfcLabel"/>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="MaterialColour_3yAyxI68v5rR3KlzC79inK" Name="MaterialColour" UniqueId="fc2bced2-188e-45d5-b0d4-bfd30726cc54" PrimaryDataType="IfcLabel" />
 

--- a/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
+++ b/IFC4x3/Sections/Core data schemas/Schemas/IfcProductExtension/Entities/IfcVoxelData/DocEntity.xml
@@ -6,3 +6,4 @@
 		</DocAttribute>
 	</Attributes>
 </DocEntity>
+

--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcStructuralElementsDomain/Entities/IfcTendonConduit/DocEntity.xml
@@ -19,3 +19,4 @@
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
+

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcCompositeCurveSegment/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Entities/IfcCompositeCurveSegment/DocEntity.xml
@@ -24,3 +24,4 @@
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>
+

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
@@ -18,7 +18,7 @@
 								</DocModelRuleEntity>
 								<DocModelRuleEntity Name="IfcLinearPositioningElement">
 									<Rules>
-										<DocModelRuleAttribute Name="Name">
+										<DocModelRuleAttribute Name="LinearPositioningElementName">
 											<Rules>
 												<DocModelRuleEntity Name="IfcLabel" />
 											</Rules>

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
@@ -16,6 +16,15 @@
 										</DocModelRuleAttribute>
 									</Rules>
 								</DocModelRuleEntity>
+								<DocModelRuleEntity Name="IfcLinearPositioningElement">
+									<Rules>
+										<DocModelRuleAttribute Name="Name">
+											<Rules>
+												<DocModelRuleEntity Name="IfcLabel" />
+											</Rules>
+										</DocModelRuleAttribute>
+									</Rules>
+								</DocModelRuleEntity>
 							</Rules>
 						</DocModelRuleAttribute>
 					</Rules>

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/DocTemplateDefinition.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Linear Composition" UniqueId="562f6342-e8e3-4551-ac5d-0d2724639975" Type="IfcLinearPositioningElement">
+	<Rules>
+		<DocModelRuleAttribute Name="Decomposes">
+			<Rules>
+				<DocModelRuleEntity Name="IfcRelAggregates">
+					<Rules>
+						<DocModelRuleAttribute Name="RelatingObject" Identification="RelatingObject">
+							<Rules>
+								<DocModelRuleEntity Name="IfcProject">
+									<Rules>
+										<DocModelRuleAttribute Name="Name" Identification="ProjectName">
+											<Rules>
+												<DocModelRuleEntity Name="IfcLabel" />
+											</Rules>
+										</DocModelRuleAttribute>
+									</Rules>
+								</DocModelRuleEntity>
+							</Rules>
+						</DocModelRuleAttribute>
+					</Rules>
+				</DocModelRuleEntity>
+			</Rules>
+		</DocModelRuleAttribute>
+	</Rules>
+</DocTemplateDefinition>
+

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/Documentation.md
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Composition/Documentation.md
@@ -1,0 +1,1 @@
+Provision of a linear structure of the project by aggregating linear positioning elements. The linear structure is a hierarchical tree of linear positioning elements ultimately assigned to the project. Composition refers to the relationship to a higher level element (e.g. linear positioning element is part of a project).

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Decomposition/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Decomposition/DocTemplateDefinition.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Linear Decomposition" UniqueId="4fa7125d-891e-471f-b1f3-e577390eb4f3" Type="IfcProject">
+	<Rules>
+		<DocModelRuleAttribute Name="IsDecomposedBy">
+			<Rules>
+				<DocModelRuleEntity Name="IfcRelAggregates">
+					<Rules>
+						<DocModelRuleAttribute Name="RelatedObjects" Identification="RelatedObjects">
+							<Rules>
+								<DocModelRuleEntity Name="IfcLinearPositioningElement">
+									<Rules>
+										<DocModelRuleAttribute Name="Name" Identification="LinearPositioningElementName">
+											<Rules>
+												<DocModelRuleEntity Name="IfcLabel" />
+											</Rules>
+										</DocModelRuleAttribute>
+									</Rules>
+								</DocModelRuleEntity>
+							</Rules>
+						</DocModelRuleAttribute>
+					</Rules>
+				</DocModelRuleEntity>
+			</Rules>
+		</DocModelRuleAttribute>
+	</Rules>
+</DocTemplateDefinition>
+

--- a/IFC4x3/Templates/Object Composition/Aggregation/Linear Decomposition/Documentation.md
+++ b/IFC4x3/Templates/Object Composition/Aggregation/Linear Decomposition/Documentation.md
@@ -1,0 +1,1 @@
+Provision of a linear structure of the project by aggregating linear positioning elements. The linear structure is a hierarchical tree of linear positioning elements ultimately assigned to the project. Composition refers to the relationship to a lower level element (e.g. project has linear positioning elements).

--- a/IFC4x3/Templates/Object Connectivity/Station/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Object Connectivity/Station/DocTemplateDefinition.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Station_0a_CIglHH8wBXulkH9IhxC" Name="Station" UniqueId="24f8c4aa-bd14-48e8-b878-bee4494abecc" Type="IfcReferent">
+	<Rules>
+		<DocModelRuleAttribute Name="Positions">
+			<Rules>
+				<DocModelRuleEntity Name="IfcRelPositions">
+					<Rules>
+						<DocModelRuleAttribute Name="RelatedProducts" Identification="RelatedProducts">
+							<Rules>
+								<DocModelRuleEntity Name="IfcProduct">
+									<Rules>
+										<DocModelRuleAttribute Name="Name" Identification="ProductName">
+											<Rules>
+												<DocModelRuleEntity Name="IfcLabel" />
+											</Rules>
+										</DocModelRuleAttribute>
+									</Rules>
+								</DocModelRuleEntity>
+							</Rules>
+						</DocModelRuleAttribute>
+					</Rules>
+				</DocModelRuleEntity>
+			</Rules>
+		</DocModelRuleAttribute>
+		<DocModelRuleAttribute Name="ObjectPlacement" Identification="HasObjectPlacement">
+			<Rules>
+				<DocModelRuleEntity Name="IfcObjectPlacement" />
+			</Rules>
+		</DocModelRuleAttribute>
+	</Rules>
+</DocTemplateDefinition>
+

--- a/IFC4x3/Templates/Object Connectivity/Station/Documentation.md
+++ b/IFC4x3/Templates/Object Connectivity/Station/Documentation.md
@@ -1,1 +1,3 @@
 Station for element template.
+
+An _IfcElement_ may have a linear referencing measurement attached to it. The _IfcReferent_.Name features a localized form of station measurement encodings and shall be positioned on an _IfcAlignment_ to ensure that a distance along measurement is clearly defined. The _IfcReferent_ should have a placement.

--- a/IFC4x3/Templates/Object Connectivity/Station/Documentation.md
+++ b/IFC4x3/Templates/Object Connectivity/Station/Documentation.md
@@ -1,0 +1,1 @@
+Station for element template.

--- a/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/DocTemplateDefinition.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocTemplateDefinition xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Product_Relative_Placement_3qqFBayh18_9VwpdiT9QZ9" Name="Product Relative Placement" UniqueId="f4d0f2e4-f2b0-48f8-97fa-ce7b1d25a8c9" Type="IfcProduct">
+	<Rules>
+		<DocModelRuleAttribute Name="ObjectPlacement" Identification="HasPlacement">
+			<Rules>
+				<DocModelRuleEntity Name="IfcObjectPlacement">
+					<Rules>
+						<DocModelRuleAttribute Name="PlacementRelTo">
+							<Rules>
+								<DocModelRuleEntity Name="IfcObjectPlacement">
+									<Rules>
+										<DocModelRuleAttribute Name="PlacesObject" Identification="RelativeToElement">
+											<Rules>
+												<DocModelRuleEntity Name="IfcPositioningElement">
+													<Rules>
+														<DocModelRuleAttribute Name="Name" Identification="PositioningElementName">
+															<Rules>
+																<DocModelRuleEntity Name="IfcLabel" />
+															</Rules>
+														</DocModelRuleAttribute>
+													</Rules>
+												</DocModelRuleEntity>
+											</Rules>
+										</DocModelRuleAttribute>
+									</Rules>
+								</DocModelRuleEntity>
+							</Rules>
+						</DocModelRuleAttribute>
+					</Rules>
+				</DocModelRuleEntity>
+			</Rules>
+		</DocModelRuleAttribute>
+	</Rules>
+</DocTemplateDefinition>
+

--- a/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
+++ b/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
@@ -1,3 +1,3 @@
 Relative placement to positioning element.
 
-Any _IfcProduct_ may have a direct reference to the _IfcAligmnent_ on which it is placed. This is an exception where no measurements in the form of stationing values are required. The placement is always relative to the underlying _IfcAlignment_.Representation (allowed geometric items are certain types of curves) with an absolute measurement from the start of the representing curve at zero parameter length.
+Any _IfcProduct_ may have a direct reference to the _IfcAlignment_ on which it is placed. This is an exception where no measurements in the form of stationing values are required. The placement is always relative to the underlying _IfcAlignment_.Representation (allowed geometric items are certain types of curves) with an absolute measurement from the start of the representing curve at zero parameter length.

--- a/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
+++ b/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
@@ -1,1 +1,3 @@
 Relative placement to positioning element.
+
+Any _IfcProduct_ may have a direct reference to the _IfcAligmnent_ on which it is placed. This is an exception where no measurements in the form of stationing values are required. The placement is always relative to the underlying _IfcAlignment_.Representation (allowed geometric items are certain types of curves) with an absolute measurement from the start of the representing curve at zero parameter length.

--- a/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
+++ b/IFC4x3/Templates/Product Shape/Product Placement/Product Relative Placement/Documentation.md
@@ -1,0 +1,1 @@
+Relative placement to positioning element.


### PR DESCRIPTION
1. [linear composition template](https://github.com/bSI-InfraRoom/IFC-Specification/commit/7ef8f509b078b4685528e7ca944a83a203681260)
2. [linear decomposition template](https://github.com/bSI-InfraRoom/IFC-Specification/commit/e22ded9e86cdd44165850be8a5497961a52e6376)
3. [station template](https://github.com/bSI-InfraRoom/IFC-Specification/commit/066d8773ef2f90e22ae21dbff4f0f5e2dd9b61cf)
4. [relative placement template](https://github.com/bSI-InfraRoom/IFC-Specification/commit/dd6ac2b8408905f51cc998f25408f2c0b8da618f)
5. [adding referent to gu](https://github.com/bSI-InfraRoom/IFC-Specification/commit/3bfcfdd0f5deb4d7bd5032b58293f3cf817b3b9e)

I guess we need more than just linear de/-composition.

EDIT: two remarks IMO:
1. in GU `IfcReferent.Station` should be restricted to `IfcElement` or `IfcSpatial(Structure)Element` (the same then for Product Relative Placement on `IfcElement` in `IfcSpatial(Structure)Element)`
2. I also think that Linear De/-Composition (maybe not Co) should reference `Stationing` (i. e. nesting of `IfcReferent`)
3. See https://github.com/bSI-InfraRoom/IFC-Specification/pull/557#discussion_r1138244564