### PR TITLE
fix schema reference in OnlyProjectedCRS rule

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
@@ -39,7 +39,7 @@ _XAxisAbscissa_ it provides the direction of the local x axis within the horizon
 	<WhereRules>
 		<DocWhereRule Name="OnlyProjectedCRS" UniqueId="ac9fb308-c18a-436f-8ec4-d0591f1dca67">
 			<Documentation>_IfcCoordinateOperation_.TargetCRS is of type _IfcGeographicCRS_.</Documentation>
-			<Expression>&apos;IFC4x3.IFCPROJECTEDCRS&apos; IN TYPEOF(SELF\IfcCoordinateOperation.TargetCRS)</Expression>
+			<Expression>&apos;IFCPROJECTEDCRS&apos; IN TYPEOF(SELF\IfcCoordinateOperation.TargetCRS)</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>


### PR DESCRIPTION
Fixes #559 

1. removing schema reference because IfcProjectedCRS and IfcMapConversion are in the same subschema IfcRepresentationResource - [fix schema reference in OnlyProjectedCRS rule](https://github.com/bSI-InfraRoom/IFC-Specification/commit/5b81e11d1bc16421ae13d97b9690e0725cfd5dcf)