### PR TITLE
Schema reference in IfcMapConversion.OnlyProjectedCRS

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
@@ -39,7 +39,7 @@ _XAxisAbscissa_ it provides the direction of the local x axis within the horizon
 	<WhereRules>
 		<DocWhereRule Name="OnlyProjectedCRS" UniqueId="ac9fb308-c18a-436f-8ec4-d0591f1dca67">
 			<Documentation>_IfcCoordinateOperation_.TargetCRS is of type _IfcGeographicCRS_.</Documentation>
-			<Expression>&apos;IFCPROJECTEDCRS&apos; IN TYPEOF(SELF\IfcCoordinateOperation.TargetCRS)</Expression>
+			<Expression>&apos;IFCREPRESENTATIONRESOURCE.IFCPROJECTEDCRS&apos; IN TYPEOF(SELF\IfcCoordinateOperation.TargetCRS)</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>


### PR DESCRIPTION
1. [added schema reference](https://github.com/bSI-InfraRoom/IFC-Specification/commit/064ee839c90cdff25d25078f9670539fb986ce2e)

Apparently I do need a stub for the schema generation. Apologies.