### PR TITLE
Add Qto_ExcavationBaseQuantities

### DIFF
--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ExcavationBaseQuantities/DocQuantitySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ExcavationBaseQuantities/DocQuantitySet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocQuantitySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Qto_ExcavationBaseQuantities" UniqueId="7664b932-a766-4552-b766-9c2c18a60d97" ApplicableType="IfcExcavation">
+	<Quantities>
+		<DocQuantity xsi:nil="true" href="Length_12VlqG8sb7DQA2dQlUV7OR" />
+		<DocQuantity xsi:nil="true" href="Width_2vkF8AsQL5fg4keqWbdE8G" />
+		<DocQuantity xsi:nil="true" href="Depth_1EfY1EUxjCYfMfDim4N8cC" />
+		<DocQuantity xsi:nil="true" href="UndisturbedVolume_26rNXiavD40gy60NShbzTH" />
+		<DocQuantity xsi:nil="true" href="LooseVolume_1f8iHGSB91FBK9qA7FuE68" />
+		<DocQuantity xsi:nil="true" href="Weight_2ueoe8QyrBduWuJHsi21zb" />
+	</Quantities>
+</DocQuantitySet>
+

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ExcavationBaseQuantities/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/QuantitySets/Qto_ExcavationBaseQuantities/Documentation.md
@@ -1,0 +1,1 @@
+Base quantities for excavations.


### PR DESCRIPTION
Same definition as Qto EarthworksCutBaseQuantities which should be removed/deprecated. Only generalized to the generic type IfcExcavation.