### PR TITLE
Pset_CoveringTypeMembrane

### DIFF
--- a/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/DocProperty.xml
+++ b/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/DocProperty.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu" Name="NominalThicknessGeotextile" UniqueId="0a8a768b-0fa9-45e9-b6d2-0a9471308bf8" PrimaryDataType="IfcPositiveLengthMeasure" />

--- a/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/Documentation.md
+++ b/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/Documentation.md
@@ -1,1 +1,1 @@
-Specifies the nominal thickness of the geotextile layer (if any)
+Specifies the nominal thickness of the geotextile layer (if any).

--- a/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/Documentation.md
+++ b/IFC4x3/Properties/n/NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu/Documentation.md
@@ -1,0 +1,1 @@
+Specifies the nominal thickness of the geotextile layer (if any)

--- a/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/DocProperty.xml
+++ b/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/DocProperty.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="NominalThickness_2V0Kb8wcj4deqtoweJZ0L9" Name="NominalThickness" UniqueId="9f014948-ea6b-449e-8d37-cbaa138c0549" PrimaryDataType="IfcPositiveLengthMeasure" />

--- a/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/Documentation.md
+++ b/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/Documentation.md
@@ -1,0 +1,1 @@
+Specifies the nominal total thickness of the membrane (including all layers)

--- a/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/Documentation.md
+++ b/IFC4x3/Properties/n/NominalThickness_2V0Kb8wcj4deqtoweJZ0L9/Documentation.md
@@ -1,1 +1,1 @@
-Specifies the nominal total thickness of the membrane (including all layers)
+Specifies the nominal total thickness of the membrane (including all layers).

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/DocPropertySet.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_CoveringTypeMembrane" UniqueId="9b120e0f-bc9a-4c88-bc71-529709eb0411" ApplicableType="IfcCovering/MEMBRANE" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+  <Properties>
+    <DocProperty xsi:nil="true" href="NominalThickness_2V0Kb8wcj4deqtoweJZ0L9" />
+    <DocProperty xsi:nil="true" href="NominalThicknessGeotextile_0AYdQB3wb5wRRI2fHnC8lu" />
+  </Properties>
+</DocPropertySet>

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/Documentation.md
@@ -1,1 +1,1 @@
-Properties for coverings of type membrane
+Properties for coverings of type membrane.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedBldgElements/PropertySets/Pset_CoveringTypeMembrane/Documentation.md
@@ -1,0 +1,1 @@
+Properties for coverings of type membrane


### PR DESCRIPTION
# Pset: Pset_CoveringTypeMembrane

## Applicability: IfcCovering/MEMBRANE

## Description: 

Properties for coverings of type membrane

| Property                   | Datatype                 | Description                                                  |
| -------------------------- | ------------------------ | ------------------------------------------------------------ |
| Material                   | IfcLabel                 | Use IfcMaterialLayerSet - Not part of the Pset/Qto           |
| NominalThickness           | IfcPositiveLengthMeasure | Specifies the nominal total thickness of the membrane (including all layers) |
| NominalThicknessGeotextile | IfcPositiveLengthMeasure | Specifies the nominal thickness of the geotextile layer (if any) |