### PR TITLE
BookA-Pset_InSituTestCommon

### DIFF
--- a/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/DocProperty.xml
+++ b/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/DocProperty.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="DepthRange_2ZH4HxFCT21QZcxH5WymAo" Name="DepthRange" UniqueId="a344447b-3cc7-4205-a8e6-ed1160f302b2" PropertyType="p_boundedvalue" PrimaryDataType="IfcNonNegativeLengthMeasure" />

--- a/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/Documentation.md
+++ b/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/Documentation.md
@@ -1,1 +1,1 @@
-The depth range where the test was performed
+The depth range where the test was performed.

--- a/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/Documentation.md
+++ b/IFC4x3/Properties/d/DepthRange_2ZH4HxFCT21QZcxH5WymAo/Documentation.md
@@ -1,0 +1,1 @@
+The depth range where the test was performed

--- a/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/DocProperty.xml
+++ b/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/DocProperty.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="TestMethod_2o1_k$NgPFVvqCCR6GOF$0" Name="TestMethod" UniqueId="b207ebbf-5ea6-4f7f-9d0c-31b19060ffc0" PrimaryDataType="IfcLabel" />

--- a/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/Documentation.md
+++ b/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/Documentation.md
@@ -1,1 +1,1 @@
-The test method used
+The test method used.

--- a/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/Documentation.md
+++ b/IFC4x3/Properties/t/TestMethod_2o1_k$NgPFVvqCCR6GOF$0/Documentation.md
@@ -1,0 +1,1 @@
+The test method used

--- a/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/DocProperty.xml
+++ b/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/DocProperty.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="TestType_0bwKXZ2_vEmREG23P2KV6g" Name="TestType" UniqueId="25e94863-0bee-4ec1-b390-08364251f1aa" PrimaryDataType="IfcLabel" />

--- a/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/Documentation.md
+++ b/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/Documentation.md
@@ -1,0 +1,1 @@
+The test type

--- a/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/Documentation.md
+++ b/IFC4x3/Properties/t/TestType_0bwKXZ2_vEmREG23P2KV6g/Documentation.md
@@ -1,1 +1,1 @@
-The test type
+The test type.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/DocPropertySet.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_InSituTestCommon" UniqueId="b377ff76-f12a-4bcb-8345-3288b8f0035d" ApplicableType="IfcGeoScienceObservation/INSITUTESTRESULT" PropertySetType="PSET_OCCURRENCEDRIVEN">
+  <Properties>
+    <DocProperty xsi:nil="true" href="DepthRange_2ZH4HxFCT21QZcxH5WymAo" />
+    <DocProperty xsi:nil="true" href="TestMethod_2o1_k$NgPFVvqCCR6GOF$0" />
+    <DocProperty xsi:nil="true" href="TestType_0bwKXZ2_vEmREG23P2KV6g" />
+  </Properties>
+</DocPropertySet>

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/Documentation.md
@@ -1,0 +1,1 @@
+Properties common for in-situ tests

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_InSituTestCommon/Documentation.md
@@ -1,1 +1,1 @@
-Properties common for in-situ tests
+Properties in common for in-situ tests in soil or rock.


### PR DESCRIPTION
# Pset: Pset_InSituTestCommon

## Applicability: IfcGeoScienceObservation/INSITUTESTRESULT

## Description: 

Properties in common for in-situ tests in soil or rock.

| Property | Datatype | Description |
|----------|----------|-------------|
|DepthRange|IfcNonNegativeLengthMeasure|The depth range where the test was performed.|
|TestMethod|IfcLabel|The test method used.|
|TestType|IfcLabel|The test type.|
