### PR TITLE
Deprecation of IFC 4.3 IfcGeotechnicalElement and subtypes

### DIFF
--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeomodel/DocEntity.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeomodel/DocEntity.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeomodel" UniqueId="b445a89d-52a3-4a2d-99fe-f3c180d3066a" BaseDefinition="IfcGeotechnicalAssembly" EntityFlags="32" />
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeomodel" UniqueId="b445a89d-52a3-4a2d-99fe-f3c180d3066a" Status="Deprecated" BaseDefinition="IfcGeotechnicalAssembly" EntityFlags="32" />
 

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeomodel/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeomodel/Documentation.md
@@ -1,2 +1,4 @@
 Representation of the concept of a volumetric geological and geotechnical model, usually an interpretation but sometimes created direct from ground penetrating measurement.
 The assembly may contain one of more strata and other anthropic elements. The contained subtypes of _IfcGeotechnicalStratum_ will have shape representations made from polyhedra or surfaces if a 'Yabuki' top surface model is being used.
+
+> DEPRECATION&nbsp; The entity _IfcGeomodel_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeoslice/DocEntity.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeoslice/DocEntity.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeoslice" UniqueId="441764ee-c125-4679-8415-f87449b952ad" BaseDefinition="IfcGeotechnicalAssembly" EntityFlags="32" />
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeoslice" UniqueId="441764ee-c125-4679-8415-f87449b952ad" Status="Deprecated" BaseDefinition="IfcGeotechnicalAssembly" EntityFlags="32" />
 

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeoslice/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeoslice/Documentation.md
@@ -1,1 +1,3 @@
 Representation of the concept of a sectional planar geological and geotechnical model, usually an interpretation but sometimes created direct from ground penetrating measurement. The assembly may contain one of more strata and anthropic elements. The contained subtypes of _IfcGeotechnicalStratum_ will have shape representations made from polygons reflecting the visible section or poly lines if a 'Yabuki' top surface model is being used.
+
+> DEPRECATION&nbsp; The entity _IfcGeoSlice_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly/DocEntity.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly/DocEntity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeotechnicalAssembly" UniqueId="85b77fde-67ea-40a4-ada4-add4c95a7d3e" BaseDefinition="IfcGeotechnicalElement">
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeotechnicalAssembly" UniqueId="85b77fde-67ea-40a4-ada4-add4c95a7d3e" Status="Deprecated" BaseDefinition="IfcGeotechnicalElement">
 	<Subtypes>
 		<DocSubtype UniqueId="f997e17a-fe30-4c4f-86a1-d45915ff91f0" DefinedType="IfcBorehole" />
 		<DocSubtype UniqueId="dfa20a1b-5cf0-4c77-a41a-0efc12e721c5" DefinedType="IfcGeoslice" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly/Documentation.md
@@ -2,3 +2,5 @@ Representation of the abstract concept of a geological and geotechnical model, u
 Use of an assembly is optional but can carry the methodology and uncertainty information.
 Such assemblies will include _IfcGeotechnicalStratum_ entity types and may include other entity types such as _IfcPile_, _IfcSlab_ or _IfcSensor_ to represent the capping, lining or logging equipment present.
 _IfcBorehole_ or _IfcGeoSlice_  can have a physical reality as a construction hazard alongside being the carrier for the interpreted results. Geological hazards may be associated to any _IfcGeotechnicalAssembly_ or _IfcGeotechnicalStratum_.
+
+> DEPRECATION&nbsp; The entity _IfcGeotechnicalAssembly_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement/DocEntity.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement/DocEntity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcGeotechnicalElement" Name="IfcGeotechnicalElement" UniqueId="d0319b84-7bde-49d9-a41e-7ecff68ba94e" BaseDefinition="IfcElement">
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcGeotechnicalElement" Name="IfcGeotechnicalElement" UniqueId="d0319b84-7bde-49d9-a41e-7ecff68ba94e" Status="Deprecated" BaseDefinition="IfcElement">
 	<Subtypes>
 		<DocSubtype UniqueId="f46dda16-3389-45c1-a7ab-9ee4dc9c5c41" DefinedType="IfcGeotechnicalStratum" />
 		<DocSubtype UniqueId="83bae2d6-e7ed-440e-8e1e-3ad2c5520b37" DefinedType="IfcGeotechnicalAssembly" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement/Documentation.md
@@ -1,1 +1,3 @@
 Abstract supertype for geotechnical entities.
+
+> DEPRECATION&nbsp; The entity _IfcGeotechnicalElement_ shall not be used anymore, use _IfcGeoScienceElement_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum/DocEntity.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum/DocEntity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeotechnicalStratum" UniqueId="faefb134-3800-4995-b222-b921d7e287bf" BaseDefinition="IfcGeotechnicalElement" EntityFlags="32">
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcGeotechnicalStratum" UniqueId="faefb134-3800-4995-b222-b921d7e287bf" Status="Deprecated" BaseDefinition="IfcGeotechnicalElement" EntityFlags="32">
 	<Attributes>
 		<DocAttribute Name="PredefinedType" UniqueId="49282b29-5083-4b1e-8140-4159b6f74092" DefinedType="IfcGeotechnicalStratumTypeEnum">
 			<Documentation>A list of types to further identify the object. Some property sets may be specifically applicable to one of these types.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum/Documentation.md
@@ -1,2 +1,4 @@
 Representation of the concept of an identified discrete almost homogenous geological feature with either an irregular solid or 'Yabuki' top surface shape or a regular voxel cubic shape. A stratum is represented as a discrete entity, specialised (sub typed) from _IfcElement_. A stratum may be broken down into smaller entities if properties vary across the stratum or alternatively properties may be described with bounded numeric ranges. A stratum may carry information about the physical form and its interpretation as a Geological Item (GML).
 The shape representations used should correspond to the sub-type of _IfcGeotechnicalAssembly_ in which it occurs.
+
+> DEPRECATION&nbsp; The entity _IfcGeotechnicalstratum_ shall not be used anymore, use _IfcGeoScienceFeature_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/DocEnumeration.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/DocEnumeration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEnumeration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcGeotechnicalStratumTypeEnum" Name="IfcGeotechnicalStratumTypeEnum" UniqueId="fc718a6b-518a-4b21-a128-10dee068c132" DiagramNumber="1">
+<DocEnumeration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="IfcGeotechnicalStratumTypeEnum" Name="IfcGeotechnicalStratumTypeEnum" UniqueId="fc718a6b-518a-4b21-a128-10dee068c132" Status="Deprecated" DiagramNumber="1">
 	<DiagramRectangle xsi:type="DocRectangle" X="0" Y="0" Width="400" Height="100" />
 	<Constants>
 		<DocConstant xsi:nil="true" href="SOLID_0hCk8da6HBZAf0CKpzqv2y" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/Documentation.md
@@ -1,3 +1,3 @@
 This container defines the different predefined types of stratum elements that can further specify an _IfcGeotechnicalStratum_.
 
-> DEPRECATION&nbsp; The entity _IfcGeotechnicalStratumTypeEnum_ shall not be used anymore due to deprecation of _IfcGeotechnicalStratum_, Instead use _IfcGeoScienceFeature_ including _IfcGeoScienceFeatureTypeEnum_.
+> DEPRECATION&nbsp; The entity _IfcGeotechnicalStratumTypeEnum_ shall not be used anymore due to deprecation of _IfcGeotechnicalStratum_. Use _IfcGeoScienceFeature_ including _IfcGeoScienceFeatureTypeEnum_ instead.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/Types/IfcGeotechnicalStratumTypeEnum/Documentation.md
@@ -1,1 +1,3 @@
 This container defines the different predefined types of stratum elements that can further specify an _IfcGeotechnicalStratum_.
+
+> DEPRECATION&nbsp; The entity _IfcGeotechnicalStratumTypeEnum_ shall not be used anymore due to deprecation of _IfcGeotechnicalStratum_, Instead use _IfcGeoScienceFeature_ including _IfcGeoScienceFeatureTypeEnum_.


### PR DESCRIPTION
Fixes #371

Please note that IfcBorehole is still used but was moved (subtype to IfcGeoScienceElement) in another PR.