### PR TITLE
Material properties template

### DIFF
--- a/IFC4x3/Templates/Partial Templates/Material Definition/Material/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Material Definition/Material/DocTemplateDefinition.xml
@@ -16,6 +16,34 @@
 				<DocModelRuleEntity Name="IfcLabel" />
 			</Rules>
 		</DocModelRuleAttribute>
+		<DocModelRuleAttribute Name="HasProperties" Identification="HasProperties">
+			<Rules>
+				<DocModelRuleEntity Name="IfcMaterialProperties">
+					<Rules>
+						<DocModelRuleAttribute Name="Name" Identification="PsetName">
+							<Rules>
+								<DocModelRuleEntity Name="IfcIdentifier" />
+							</Rules>
+						</DocModelRuleAttribute>
+						<DocModelRuleAttribute Name="Description">
+							<Rules>
+								<DocModelRuleEntity Name="IfcText" />
+							</Rules>
+						</DocModelRuleAttribute>
+						<DocModelRuleAttribute Name="Properties" Identification="PsetProperties">
+							<Rules>
+								<DocModelRuleEntity Name="IfcPropertySingleValue" />
+								<DocModelRuleEntity Name="IfcPropertyBoundedValue" />
+								<DocModelRuleEntity Name="IfcPropertyEnumeratedValue" />
+								<DocModelRuleEntity Name="IfcPropertyListValue" />
+								<DocModelRuleEntity Name="IfcPropertyTableValue" />
+								<DocModelRuleEntity Name="IfcPropertyReferenceValue" />
+							</Rules>
+						</DocModelRuleAttribute>
+					</Rules>
+				</DocModelRuleEntity>
+			</Rules>
+		</DocModelRuleAttribute>
 	</Rules>
 </DocTemplateDefinition>
 

--- a/IFC4x3/Templates/Partial Templates/Material Definition/Material/DocTemplateDefinition.xml
+++ b/IFC4x3/Templates/Partial Templates/Material Definition/Material/DocTemplateDefinition.xml
@@ -30,7 +30,7 @@
 								<DocModelRuleEntity Name="IfcText" />
 							</Rules>
 						</DocModelRuleAttribute>
-						<DocModelRuleAttribute Name="Properties" Identification="PsetProperties">
+						<DocModelRuleAttribute Name="Properties" Identification="MaterialProperties">
 							<Rules>
 								<DocModelRuleEntity Name="IfcPropertySingleValue" />
 								<DocModelRuleEntity Name="IfcPropertyBoundedValue" />


### PR DESCRIPTION
Adding material properties to partial template Material. 
Since IfcMaterialDefinition is not rooted, this might be a cleaner solution than what is done here: https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/concepts/Object_Definition/Property_Sets/Property_Sets_for_Materials/content.html 
Partly fixes #649.