### PR TITLE
EXC-GI_PsetEarthworksCutTypeTrench

### DIFF
--- a/IFC4x3/Properties/c/CatchmentArea_2p1YWircfCd8rNYaGGPhaC/DocProperty.xml
+++ b/IFC4x3/Properties/c/CatchmentArea_2p1YWircfCd8rNYaGGPhaC/DocProperty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="CatchmentArea_2p1YWircfCd8rNYaGGPhaC" Name="CatchmentArea" UniqueId="b306282c-d66a-4c9c-8d57-8a441066b90c" PrimaryDataType="IfcAreaMeasure" />
+

--- a/IFC4x3/Properties/c/CatchmentArea_2p1YWircfCd8rNYaGGPhaC/Documentation.md
+++ b/IFC4x3/Properties/c/CatchmentArea_2p1YWircfCd8rNYaGGPhaC/Documentation.md
@@ -1,0 +1,1 @@
+Area flowing into sump.

--- a/IFC4x3/Properties/v/VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW/DocProperty.xml
+++ b/IFC4x3/Properties/v/VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW/DocProperty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW" Name="VolumetricCapacity" UniqueId="272e66ab-b70e-4df0-a4ee-7eeea601aee0" PrimaryDataType="IfcVolumeMeasure" />
+

--- a/IFC4x3/Properties/v/VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW/Documentation.md
+++ b/IFC4x3/Properties/v/VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW/Documentation.md
@@ -1,0 +1,1 @@
+Capacity of Trench/Sump.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/DocPropertySet.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_EarthworksCutTypeTrench" UniqueId="00d7d840-19c4-4b33-b82c-80da2b7bf10c" ApplicableType="IfcEarthworksCut/(.TRENCH.)" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+	<Properties>
+		<DocProperty xsi:nil="true" href="CatchmentArea_2p1YWircfCd8rNYaGGPhaC" />
+		<DocProperty xsi:nil="true" href="NominalDepth_0HZnE0qUaHuO00025QrEV" />
+		<DocProperty xsi:nil="true" href="NominalWidth_2YZfyYRY1Aa9bsWGvZEaNq" />
+		<DocProperty xsi:nil="true" href="NominalLength_07RHK0qUaHuO00025QrEV" />
+		<DocProperty xsi:nil="true" href="VolumetricCapacity_0dBcQhjmvDyAJkVkwc0QxW" />
+	</Properties>
+</DocPropertySet>
+

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/DocPropertySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_EarthworksCutTypeTrench" UniqueId="00d7d840-19c4-4b33-b82c-80da2b7bf10c" ApplicableType="IfcEarthworksCut/(.TRENCH.)" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_EarthworksCutTypeTrench" UniqueId="00d7d840-19c4-4b33-b82c-80da2b7bf10c" ApplicableType="IfcEarthworksCut/TRENCH" PropertySetType="PSET_TYPEDRIVENOVERRIDE">
 	<Properties>
 		<DocProperty xsi:nil="true" href="CatchmentArea_2p1YWircfCd8rNYaGGPhaC" />
 		<DocProperty xsi:nil="true" href="NominalDepth_0HZnE0qUaHuO00025QrEV" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_EarthworksCutTypeTrench/Documentation.md
@@ -1,0 +1,1 @@
+Properties for trenches/sumps.


### PR DESCRIPTION
# Pset: Pset_EarthworksCutTypeTrench

## Applicability: IfcEarthworksCut/TRENCH

## Description:

Properties for trenches/sumps.

| Property              | Datatype                   | Description                                        |
| --------------------- | -------------------------- | -------------------------------------------------- |
| CatchmentArea         | IfcAreaMeasure        | Area flowing into sump.             |
| NominalDepth | IfcNonNegativeLengthMeasure | Existing property.         |
| NominalWidth | IfcNonNegativeLengthMeasure | Existing property.         |
| NominalLength | IfcNonNegativeLengthMeasure | Existing property.         |
| VolumetricCapacity     | IfcVolumeMeasure   | Capacity of Trench/Sump.          |
