### PR TITLE
EX-PS_Pset_ElementAssemblyTypePreSupportFace

### DIFF
--- a/IFC4x3/Properties/t/TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q/DocProperty.xml
+++ b/IFC4x3/Properties/t/TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q/DocProperty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q" Name="TransverseBoreholeSpacing" UniqueId="79c6f20f-4fce-4cab-8344-87413d4fd15a" PrimaryDataType="IfcPositiveLengthMeasure" />
+

--- a/IFC4x3/Properties/t/TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q/Documentation.md
+++ b/IFC4x3/Properties/t/TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q/Documentation.md
@@ -1,0 +1,1 @@
+Transverse spacing between boreholes.

--- a/IFC4x3/Properties/v/VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v/DocProperty.xml
+++ b/IFC4x3/Properties/v/VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v/DocProperty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocProperty xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v" Name="VerticalBoreholeSpacing" UniqueId="838bc164-612a-4f8f-acfa-b4562d1130f9" PrimaryDataType="IfcPositiveLengthMeasure" />
+

--- a/IFC4x3/Properties/v/VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v/Documentation.md
+++ b/IFC4x3/Properties/v/VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v/Documentation.md
@@ -1,0 +1,1 @@
+Vertical spacing between boreholes.

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/DocPropertySet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_ElementAssemblyTypePreSupportFace" UniqueId="1c6de242-8ceb-4f46-91f8-f072d6a50084" ApplicableType="IfcElementAssembly">
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_ElementAssemblyTypePreSupportFace" UniqueId="1c6de242-8ceb-4f46-91f8-f072d6a50084" ApplicableType="IfcElementAssembly/.PRESUPPORTFACE.">
 	<Properties>
 		<DocProperty xsi:nil="true" href="TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q" />
 		<DocProperty xsi:nil="true" href="VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v" />

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/DocPropertySet.xml
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/DocPropertySet.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocPropertySet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Pset_ElementAssemblyTypePreSupportFace" UniqueId="1c6de242-8ceb-4f46-91f8-f072d6a50084" ApplicableType="IfcElementAssembly">
+	<Properties>
+		<DocProperty xsi:nil="true" href="TransverseBoreholeSpacing_1vnl8FJyvCguD4Xq4zJz5Q" />
+		<DocProperty xsi:nil="true" href="VerticalBoreholeSpacing_23Yy5aOIfFZwpwj5Oj4J3v" />
+	</Properties>
+</DocPropertySet>
+

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/Documentation.md
@@ -1,0 +1,1 @@
+Properties for element assemblies of type PRESUPPORTFACE. (Update applicability to IfcElementAssembly/PRESUPPORTFACE when PR with PDTs for IfcElementAssembly has been merged)

--- a/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/Documentation.md
+++ b/IFC4x3/Sections/Shared element data schemas/Schemas/IfcSharedInfrastructureElements/PropertySets/Pset_ElementAssemblyTypePreSupportFace/Documentation.md
@@ -1,1 +1,1 @@
-Properties for element assemblies of type PRESUPPORTFACE. (Update applicability to IfcElementAssembly/PRESUPPORTFACE when PR with PDTs for IfcElementAssembly has been merged)
+Properties for element assemblies of type PRESUPPORTFACE.


### PR DESCRIPTION
# Pset: Pset_ElementAssemblyTypePreSupportFace

## Applicability: IfcElementAssembly/PRESUPPORTFACE

## Description: 

Properties for element assemblies of type PRESUPPORTFACE. 

| Property | Datatype | Description |
|----------|----------|-------------|
|TransverseBoreholeSpacing| IfcPositiveLengthMeasure |Transverse spacing between boreholes.|
|VerticalBoreholeSpacing|IfcPositiveLengthMeasure|Vertical spacing between boreholes.|