### PR TITLE
fix type in IfcTransformer.CorrectPredefinedType

### DIFF
--- a/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcElectricalDomain/Entities/IfcTransformer/DocEntity.xml
+++ b/IFC4x3/Sections/Domain specific data schemas/Schemas/IfcElectricalDomain/Entities/IfcTransformer/DocEntity.xml
@@ -18,7 +18,7 @@
 		<DocWhereRule Name="CorrectTypeAssigned" UniqueId="75b0f680-06c7-44ef-9309-04bc68af656b">
 			<Documentation>Either there is no transformer type object associated, i.e. the _IsTypedBy_ inverse relationship is not provided, or the associated type object has to be of type _IfcTransformerType_.</Documentation>
 			<Expression>(SIZEOF(IsTypedBy) = 0) OR 
-  (&apos;IFCELECTRICALDOMAIN.IFCTRANFORMERTYPE&apos; IN TYPEOF(SELF\IfcObject.IsTypedBy[1].RelatingType))</Expression>
+  (&apos;IFCELECTRICALDOMAIN.IFCTRANSFORMERTYPE&apos; IN TYPEOF(SELF\IfcObject.IsTypedBy[1].RelatingType))</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>


### PR DESCRIPTION
Fix #695 
[fix type in IfcTransformer.CorrectPredefinedType](https://github.com/bSI-InfraRoom/IFC-Specification/commit/12a55415f15d7540438f5dfaa32c32812a34c1fb)
