### PR TITLE
Reconcile/ifc quantity number

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Types/IfcCurveMeasureSelect/DocSelect.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Types/IfcCurveMeasureSelect/DocSelect.xml
@@ -5,3 +5,4 @@
 		<DocSelectItem Name="IfcLengthMeasure" UniqueId="ea35632d-740b-40e1-968d-de8a492a0e4e" />
 	</Selects>
 </DocSelect>
+

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcMeasureResource/Types/IfcCountMeasure/DocDefined.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcMeasureResource/Types/IfcCountMeasure/DocDefined.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocDefined xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcCountMeasure" UniqueId="db0ab29e-50b3-4287-9272-e06513097a5a" DefinedType="NUMBER">
+<DocDefined xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcCountMeasure" UniqueId="db0ab29e-50b3-4287-9272-e06513097a5a" DefinedType="INTEGER">
 	<Localization>
 		<DocLocalization Locale="en" Name="Count Measure" />
 		<DocLocalization Locale="fr" Name="Mesure du nombre" />
 	</Localization>
-	<Definition xsi:type="DocPrimitive" xsi:nil="true" href="NUMBER_3AYiD8s_rAOu2IDHGD82pn" />
+	<Definition xsi:type="DocPrimitive" xsi:nil="true" href="INTEGER_0Bo9r4fCj07e5rVk1a6n_D" />
 </DocDefined>
 

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcMeasureResource/Types/IfcCountMeasure/Documentation.md
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcMeasureResource/Types/IfcCountMeasure/Documentation.md
@@ -1,7 +1,9 @@
 A count measure is the value of a count of items.
 
-Type: NUMBER
+Type: INTEGER
 
 > NOTE&nbsp; Type adapted from **count_measure** defined in ISO 10303-41.
 
 > HISTORY&nbsp; New type in IFC1.5.1.
+
+> HISTORY IFC4.3.0.0 Type changed from NUMBER to INTEGER

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/DocSchema.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/DocSchema.xml
@@ -13,12 +13,13 @@
 				<DocDefinitionRef Name="IfcVolumeMeasure" UniqueId="9ad84159-4e40-4f61-9a45-840475371022" />
 				<DocDefinitionRef Name="IfcCountMeasure" UniqueId="08783b1b-5cb9-4e98-8a6f-5b6d84a1f571" />
 				<DocDefinitionRef Name="IfcMassMeasure" UniqueId="67bbb7bb-8da3-4f83-9d15-137f66f85557" />
-				<DocDefinitionRef Name="IfcLabel" UniqueId="d0811385-d914-4e39-88d4-77ade8afac73" />
+				<DocDefinitionRef id="IfcLabel_3GWHE5sHHEEOZKTwtehwnp" Name="IfcLabel" UniqueId="d0811385-d914-4e39-88d4-77ade8afac73" />
 				<DocDefinitionRef Name="IfcText" UniqueId="1fc47fd7-b86f-46d6-b117-b1ba5eadb5cd" />
 				<DocDefinitionRef Name="IfcNamedUnit" UniqueId="e42f2c18-9cc2-42cc-ae07-79add1d79bc5" />
 				<DocDefinitionRef Name="IfcSIUnit" UniqueId="d8b1d6af-a920-4bfe-9ae7-dabf6e0d8bb8" />
 				<DocDefinitionRef Name="IfcUnitEnum" UniqueId="029330bc-73c2-4727-8d84-0f465c528d42" />
 				<DocDefinitionRef Name="IfcTimeMeasure" UniqueId="c84e694e-553f-4b98-bb7b-3a01f4f700eb" />
+				<DocDefinitionRef id="IfcNumericMeasure_3OjK5i03jC_usduj4WHzeK" Name="IfcNumericMeasure" UniqueId="d8b5416c-003b-4cfb-8da7-e2d12047da14" />
 			</Definitions>
 		</DocSchemaRef>
 	</SchemaRefs>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/Entities/IfcQuantityNumber/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/Entities/IfcQuantityNumber/DocEntity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcQuantityNumber" UniqueId="16fe07e3-f3f2-4c92-8bc0-95c6708673b1" BaseDefinition="IfcPhysicalSimpleQuantity" EntityFlags="32">
+	<Attributes>
+		<DocAttribute Name="NumberValue" UniqueId="e5559f5b-5313-4df8-9240-3050c87e3c33" DefinedType="IfcNumericMeasure">
+			<Documentation>Count measure value of this quantity.</Documentation>
+		</DocAttribute>
+		<DocAttribute Name="Formula" UniqueId="99e394a3-25d8-42e0-ac80-f0c6f24e92ec" DefinedType="IfcLabel" AttributeFlags="1">
+			<Documentation>A formula by which the quantity has been calculated. It can be assigned in addition to the actual value of the quantity. Formulas could be mathematic calculations (like width x height), database links, or a combination. The formula is for informational purposes only.
+
+&gt; IFC4 CHANGE Attribute added to the end of the attribute list.</Documentation>
+		</DocAttribute>
+	</Attributes>
+</DocEntity>
+

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/Entities/IfcQuantityNumber/Documentation.md
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcQuantityResource/Entities/IfcQuantityNumber/Documentation.md
@@ -1,0 +1,5 @@
+> NOTE This entity is not part of a standardized schema subset or implementation level.
+
+IfcQuantityNumber is a physical quantity that defines a derived number measure (integer or non-integer) to provide an element's physical property. It is normally derived from the physical properties of the element under the specific measure rules given by a method of measurement.
+
+> HISTORY IFC4.3.0.0  New entity. It has been introduced to provide additional clarity to have IfcQuantityCount strictly constrained to an integer.


### PR DESCRIPTION
closes #768 

1. [IfcCountMeasure type changed from NUMBER to INTEGER](https://github.com/bSI-InfraRoom/IFC-Specification/commit/d6a0fc7c0acaf8185e79ea6440189802086355ec)


2. [adding IfcQuantityNumber](https://github.com/bSI-InfraRoom/IFC-Specification/commit/eab8cc2309ab3b741e427d32b84dac236327e810)

@aothms please check the documentation of IfcQuantityNumber.Formula. I think the "IFC4 CHANGE" reference there is wrong since the entity was added in 4.3.0.0. I also did not know what to do with this "> NOTE This entity is not part of a standardized schema subset or implementation level." since it is the first occurrence of such a "NOTE". Please confirm if it works the way it is.

https://github.com/buildingSMART/IFC4.3.x-development/issues/853