### PR TITLE
updating IfcRevolvedAreaSolid.AxisStartInXY where rule

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcRevolvedAreaSolid/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcRevolvedAreaSolid/DocEntity.xml
@@ -21,7 +21,7 @@
 	<WhereRules>
 		<DocWhereRule Name="AxisStartInXY" UniqueId="a9e33584-c5f8-4d10-9735-557802c9e6cf">
 			<Documentation>The start of the axis shall lie in the XY plane of the position coordinate system.</Documentation>
-			<Expression>Axis.Location.Coordinates[3] = 0.0</Expression>
+			<Expression>(&apos;IFC4X3_ADD2.IFCCARTESIANPOINT&apos; IN TYPEOF(Axis.Location)) AND (Axis.Location\IfcCartesianPoint.Coordinates[3] = 0.0)</Expression>
 		</DocWhereRule>
 		<DocWhereRule Name="AxisDirectionInXY" UniqueId="37af1dd7-3b31-40a3-864e-ab12bcd8bd97">
 			<Documentation>The direction of the axis shall be parallel to the XY plane of the position coordinate system.</Documentation>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Types/IfcCurveMeasureSelect/DocSelect.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometryResource/Types/IfcCurveMeasureSelect/DocSelect.xml
@@ -5,3 +5,4 @@
 		<DocSelectItem Name="IfcLengthMeasure" UniqueId="ea35632d-740b-40e1-968d-de8a492a0e4e" />
 	</Selects>
 </DocSelect>
+


### PR DESCRIPTION
closes #769 

1. [updating IfcRevolvedAreaSolid.AxisStartInXY where rule](https://github.com/bSI-InfraRoom/IFC-Specification/commit/93dc3296650265ed6bc7884b4bb7ae03ac4eb19f)

I think the extra type check is not necessary since `IfcAxis1Placement`.`Location` is already restricted. I think:
```
Axis.Location\IfcCartesianPoint.Coordinates[3] = 0.0
```
should do it.