### PR TITLE
Fix ifc map conversion rules

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
@@ -46,7 +46,7 @@ _XAxisAbscissa_ it provides the direction of the local x axis within the horizon
 			<Expression>(NOT EXISTS(XAxisAbscissa) AND NOT EXISTS(XAxisOrdinate)) OR
 (NOT EXISTS(XAxisAbscissa) AND XAxisOrdinate &lt;&gt; 0.0) OR
 (NOT EXISTS(XAxisOrdinate) AND XAxisAbscissa &lt;&gt; 0.0) OR
-(EXISTS(XAxisAbscissa) AND EXISTS(XAxisOrdinate) AND NOT (XAxisAbscissa = 0.0 AND XAxisOrdinate = 0.0))</Expression>
+(EXISTS(XAxisAbscissa) AND EXISTS(XAxisOrdinate) AND NOT ((XAxisAbscissa = 0.0) AND (XAxisOrdinate = 0.0)))</Expression>
 		</DocWhereRule>
 	</WhereRules>
 </DocEntity>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcRepresentationResource/Entities/IfcMapConversion/DocEntity.xml
@@ -37,7 +37,7 @@ _XAxisAbscissa_ it provides the direction of the local x axis within the horizon
 		</DocAttribute>
 	</Attributes>
 	<WhereRules>
-		<DocWhereRule Name="OnlyProjectedCRS" UniqueId="ac9fb308-c18a-436f-8ec4-d0591f1dca67">
+		<DocWhereRule Name="TargetCRSProjected" UniqueId="ac9fb308-c18a-436f-8ec4-d0591f1dca67">
 			<Documentation>_IfcCoordinateOperation_.TargetCRS is of type _IfcGeographicCRS_.</Documentation>
 			<Expression>&apos;IFCREPRESENTATIONRESOURCE.IFCPROJECTEDCRS&apos; IN TYPEOF(SELF\IfcCoordinateOperation.TargetCRS)</Expression>
 		</DocWhereRule>


### PR DESCRIPTION
Fixing required parentheses in boolean expressions and proposal for WR renaming.

1. [adding required parenthesis in IfcMapConversion.ValidXAxis](https://github.com/bSI-InfraRoom/IFC-Specification/commit/6b66aba7521f71abad2c3d8d56cb38f60932eeb0)
2. [rename IfcMapConversion.OnlyProjectedCRS to TargetCRSProjected](https://github.com/bSI-InfraRoom/IFC-Specification/commit/656c66d7068b68b70bc6b9c3d57c440414c19a5c)