### PR TITLE
inverse IfcProperty.PartOfMaterialOrProfileProperties to IfcExtendePoperties

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcPropertyResource/Entities/IfcProperty/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcPropertyResource/Entities/IfcProperty/DocEntity.xml
@@ -34,7 +34,7 @@
 		<DocAttribute Name="HasApprovals" UniqueId="a25de802-e2fe-47f2-adcd-e56cdc287d21" DefinedType="IfcResourceApprovalRelationship" AttributeFlags="1" AggregationType="3" Inverse="RelatedResourceObjects">
 			<Documentation>User-defined approvals for the property.</Documentation>
 		</DocAttribute>
-		<DocAttribute Name="PartOfMaterialProperties" UniqueId="511c11c5-4e6a-45c4-9443-8abaa143e130" DefinedType="IfcMaterialProperties" AttributeFlags="32" AggregationType="3" Inverse="Properties">
+		<DocAttribute Name="PartOfMaterialOrProfileProperties" UniqueId="511c11c5-4e6a-45c4-9443-8abaa143e130" DefinedType="IfcExtendedProperties" AttributeFlags="32" AggregationType="3" Inverse="Properties">
 			<Documentation>Reference to the _IfcMaterialProperties_ by which the _IfcProperty_ is referenced.</Documentation>
 		</DocAttribute>
 	</Attributes>


### PR DESCRIPTION
according to suggestion

[inverse IfcProperty.PartOfMaterialOrProfileProperties to IfcExtendePr…](https://github.com/bSI-InfraRoom/IFC-Specification/commit/4c3efbc43d5181efc7c0c57d4bec11f063f1cb82)

was actually intended for this but documented sloppy. thanks!

additional context for https://github.com/buildingSMART/IFC4.3.x-development/issues/614