### PR TITLE
Feature/ifc voxel grid ifc tessellated item

### DIFF
--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet/DocEntity.xml
@@ -13,9 +13,6 @@
 			<Documentation>The space dimensionality of this geometric representation item, it is always 3.</Documentation>
 			<Derived>3</Derived>
 		</DocAttribute>
-		<DocAttribute Name="HasColours" UniqueId="91135fdb-fb22-4f3b-8316-c13c64b911c0" DefinedType="IfcIndexedColourMap" AttributeFlags="32" AggregationType="3" AggregationLower="0" AggregationUpper="1" Inverse="MappedTo" XsdFormat="attribute">
-			<Documentation>Reference to the indexed colour map providing the corresponding colour RGB values to the faces of the subtypes of _IfcTessellatedFaceSet_.</Documentation>
-		</DocAttribute>
 		<DocAttribute Name="HasTextures" UniqueId="bc9e2551-f6b9-4d6e-a1ea-83aa87876820" DefinedType="IfcIndexedTextureMap" AttributeFlags="32" AggregationType="3" AggregationLower="0" AggregationUpper="0" Inverse="MappedTo" XsdFormat="element">
 			<Documentation>Reference to the indexed texture map providing the corresponding texture coordinates to the vertices bounding the faces of the subtypes of _IfcTessellatedFaceSet_.</Documentation>
 		</DocAttribute>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedItem/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcTessellatedItem/DocEntity.xml
@@ -5,5 +5,10 @@
 		<DocLocalization Locale="en" Name="Tessellated Item" />
 		<DocLocalization Locale="fr" Name="Tessellation" />
 	</Localization>
+	<Attributes>
+		<DocAttribute Name="HasColours" UniqueId="91135fdb-fb22-4f3b-8316-c13c64b911c0" DefinedType="IfcIndexedColourMap" AttributeFlags="32" AggregationType="3" AggregationLower="0" AggregationUpper="1" Inverse="MappedTo" XsdFormat="attribute">
+			<Documentation>Reference to the indexed colour map providing the corresponding colour RGB values to the faces of the subtypes of _IfcTessellatedFaceSet_.</Documentation>
+		</DocAttribute>
+	</Attributes>
 </DocEntity>
 

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcVoxelGrid/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcGeometricModelResource/Entities/IfcVoxelGrid/DocEntity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcVoxelGrid" UniqueId="c0c89e7e-f8f9-4156-aa6b-c7d8f7e9b4f3" BaseDefinition="IfcSolidModel" EntityFlags="32">
+<DocEntity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="IfcVoxelGrid" UniqueId="c0c89e7e-f8f9-4156-aa6b-c7d8f7e9b4f3" BaseDefinition="IfcTessellatedItem" EntityFlags="32">
 	<Attributes>
 		<DocAttribute Name="VoxelSizeX" UniqueId="ceb76c5f-caa2-4d51-98ab-52b1142cb762" DefinedType="IfcNonNegativeLengthMeasure">
 			<Documentation>Size of voxels in the X axis.</Documentation>

--- a/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcPresentationAppearanceResource/Entities/IfcIndexedColourMap/DocEntity.xml
+++ b/IFC4x3/Sections/Resource definition data schemas/Schemas/IfcPresentationAppearanceResource/Entities/IfcIndexedColourMap/DocEntity.xml
@@ -5,7 +5,7 @@
 		<DocLocalization Locale="en" Name="Indexed Colour Map" />
 	</Localization>
 	<Attributes>
-		<DocAttribute Name="MappedTo" UniqueId="46f7bd1c-d9b3-427b-b0c8-c3d9bcc29edd" DefinedType="IfcTessellatedFaceSet" XsdFormat="hidden">
+		<DocAttribute Name="MappedTo" UniqueId="46f7bd1c-d9b3-427b-b0c8-c3d9bcc29edd" DefinedType="IfcTessellatedItem" XsdFormat="hidden">
 			<Documentation>Reference to the _IfcTessellatedFaceSet_ to which it applies the colours and alpha channel.</Documentation>
 		</DocAttribute>
 		<DocAttribute Name="Opacity" UniqueId="95d4d17c-ac0b-4a8d-9c90-545c63064df1" Status="Official" DefinedType="IfcNormalisedRatioMeasure" AttributeFlags="1" XsdFormat="content">


### PR DESCRIPTION
two proposed changes:

1. [move IfcTessellatedFaceSet.HasColours to IfcTessellatedItem](https://github.com/bSI-InfraRoom/IFC-Specification/commit/ace6100f4ae4cabd91e27bcf117d47ec366d6ff7) - allows `IfcPolygonalFace` to utilize `IfcIndexedColourMap` on individual indices
2. [IfcTessellatedItem base type of IfcVoxelGrid](https://github.com/bSI-InfraRoom/IFC-Specification/commit/bad3e68bd9bcd424576775fcbf2b20e405bb0727) - `IfcVoxelGrid` can also take advantage of `IfcIndexedColourMap`
3. [updating the direct IfcIndexedColourMap.MappedTo](https://github.com/bSI-InfraRoom/IFC-Specification/pull/859/commits/be6140a785ebec2ab82bae99ea8788a331ecc4cf)